### PR TITLE
Add firebug option for stylus

### DIFF
--- a/src/compilers/stylus.coffee
+++ b/src/compilers/stylus.coffee
@@ -26,6 +26,7 @@ class exports.StylusCompiler extends Compiler
         compiler = stylus(data)
           .set('filename', mainFilePath)
           .set('compress', true)
+          .set('firebug', @options.stylus?.firebug)
           .include(path.join(@options.brunchPath, 'src'))
 
         if nib


### PR DESCRIPTION
Adding a option in config.yaml as :

``` yaml
stylus:
  firebug: true
```

does compile the css for the [firestylus addon](https://github.com/parallel/firestylus)
