### PR TITLE
Testrunner respects custom build path now

### DIFF
--- a/src/testrunner.coffee
+++ b/src/testrunner.coffee
@@ -45,7 +45,7 @@ exports.run = (options, callback) ->
     jsdom.env
       html: path.join brunchdir, "index.html"
       scripts: [
-        path.join brunchdir, "build/web/js/app.js"
+        path.resolve options.buildPath, "web/js/app.js"
         path.resolve __dirname, "../vendor/jasmine.js"
         "/tmp/brunchtest/specs.js"
       ]


### PR DESCRIPTION
When using the -o option to specify a custom build path, the test runner fails, because "build" was hard-coded.

For example, the following command fails:

```
$ cd /tmp
$ brunch new example -o example/bin
[04:00:52]: [Brunch]: created brunch directory layout
[04:00:52]: [Stylus]: OK.
[04:00:52]: [Stitch]: compiled.
[04:00:52]: Running tests in /tmp/example/test
[04:00:52]: Error: ENOENT, Success '/tmp/example/build/web/js/app.js'
```
