### PR TITLE
improvements to `brunch test`

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -112,6 +112,11 @@ config =
 
     test:
       help: "Run tests for a brunch project"
+      opts:
+        verbose:
+          abbr: "v"
+          flag: yes
+          help: "set verbose option for test runner"
       callback: (options) ->
         brunch.test parseOpts options
 

--- a/src/testrunner.coffee
+++ b/src/testrunner.coffee
@@ -59,7 +59,7 @@ exports.run = (options, callback) ->
         jasmineEnv = window.jasmine.getEnv()
         jasmineEnv.reporter = new TerminalReporter
           print: stream
-          verbose: yes
+          verbose: options.verbose
           color: yes
           onComplete: null
           stackFilter: null


### PR DESCRIPTION
I'm not sure what to do with `-v/--verbose` vs `-v/--version`. To me having `--version` option on every command seems a bit suboptimal. I'm not sure if you'll consider switching to `brunch version` as a command rather than an option, but that's an option. Another one is to fix nomnom so that global options won't shadow local options. Another one is not having a short version of `--version`, since it's rarely used anyway.
