### PR TITLE
add Cakefile to launch test command

### DIFF
--- a/template/base/Cakefile
+++ b/template/base/Cakefile
@@ -1,0 +1,69 @@
+{spawn} = require 'child_process'
+fs = require 'fs'
+path = require 'path'
+{log,error} = require 'util'
+
+MODEL_TEST_PATH = 'test/unit/models'
+COLLECTION_TEST_PATH = 'test/unit/collections'
+VIEW_TEST_PATH = 'test/unit/views'
+ROUTE_TEST_PATH = 'test/unit/routes'
+
+TEST_PATHS = [
+  MODEL_TEST_PATH,
+  COLLECTION_TEST_PATH,
+  VIEW_TEST_PATH,
+  ROUTE_TEST_PATH
+]
+
+TEST_COMMAND="#{__dirname}/node_modules/.bin/mocha"
+TEST_OPTIONS='-r should --growl --reporter spec'
+
+task 'test', (options)->
+  {EventEmitter} = require 'events'
+  emitter = new EventEmitter
+  emitter.once 'expanded',(paths)->
+    runMocha paths
+  target = ""
+  pathEmitter = new EventEmitter
+  count = 0
+  pathEmitter.on 'finished',(paths)->
+    count += 1
+    emitter.emit 'expanded',paths if TEST_PATHS.length is count
+  TEST_PATHS.forEach (testPath)->
+    expansionPath testPath,(result)->
+      target += result
+      pathEmitter.emit 'finished',target
+
+task 'test_models', (options)->
+  expansionPath MODEL_TEST_PATH,(target)->
+    runMocha target
+
+task 'test_collections', (options)->
+  expansionPath COLLECTION_TEST_PATH,(target)->
+    runMocha target
+
+task 'test_views', (options)->
+  expansionPath VIEW_TEST_PATH,(target)->
+    runMocha target
+
+task 'test_routes', (options)->
+  expansionPath ROUTE_TEST_PATH,(target)->
+    runMocha target
+
+runMocha = (target)->
+  log 'start test'
+  args = "#{TEST_OPTIONS} #{target}".trimRight().split(' ')
+  spawn  "#{TEST_COMMAND}",args,customFds : [0, 1, 2]
+
+expansionPath = (target,callback)->
+  expansion = ""
+  fs.readdir target,(err,files)->
+    if !files
+      error "Files aren't found. path:'#{target}'"
+      return
+    files = files.map (file)->
+      return path.join(target,file)
+    files.forEach (file)->
+      expansion += file + ' '
+    callback expansion
+

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -18,6 +18,7 @@
     "brunch-extensions": "0.1.0"
   },
   "devDependencies": {
-    
+    "mocha": "0.9.0",
+    "should": "0.5.0"
   }
 }


### PR DESCRIPTION
I wrote Cakefile for testing. This is a mocha example.If you'd like to run all unit/model tests, call `cake test_models`. If you'd like to run all unit tests, call 'cake test'.And this Cakefile launch mocha. So I added some dependencies to package.json. I added mocha and should. 
