### PR TITLE
Added buildPath to config file.

### DIFF
--- a/src/brunch.coffee
+++ b/src/brunch.coffee
@@ -36,7 +36,6 @@ config.files['#{destinationPath}'].languages['#{regExp}']: #{error}.
 # Recompiles all files in current working directory.
 # 
 # rootPath - path to application directory.
-# buildPath - (optional) path to application output directory. Default: 'build'
 # config - Parsed app config.
 # persistent - Should watcher be stopped after compiling the app first time?
 # callback - Callback that would be executed on each compilation.
@@ -109,8 +108,8 @@ directory \"#{rootPath}\" already exists"
             callback()
 
 # Build application once and execute callback.
-exports.build = (rootPath, buildPath, config, callback = (->)) ->
-  watchApplication rootPath, buildPath, config, no, callback
+exports.build = (rootPath, config, callback = (->)) ->
+  watchApplication rootPath, config, no, callback
 
 # Watch application for changes and execute callback on every compilation.
 exports.watch = (rootPath, config, callback = (->)) ->

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -45,7 +45,8 @@ commandLineConfig =
           full: 'output'
       callback: (options) ->
         config = helpers.loadConfig 'config.coffee'
-        brunch.build '.', options.buildPath, config
+        config.buildPath = options.buildPath if options.buildPath
+        brunch.build '.', config
 
     watch:
       help: 'Watch brunch directory and rebuild if something changed'


### PR DESCRIPTION
Setup watch and build commands to use the config.buildPath property by default allow them to be overridden by the command line options.
