### PR TITLE
A customizable server invoked by watch --server

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -146,18 +146,13 @@ exports.sort = (files, config) ->
             # these two items.
             0
 
-exports.startServer = (port = 3333, path = '.', callback = (->)) ->
-  server = express.createServer()
-  server.configure ->
-    server.use express.static path
-    server.set 'views', path
-    server.set 'view options', layout: no
-    server.register '.html', compile: (str, options) -> (locals) -> str
-  server.get '/', (req, res) ->
-    res.render 'index.html'
-  server.listen parseInt port, 10
-  server.on 'listening', callback
-  exports.log "[Brunch]: application starting on http://0.0.0.0:#{port}."
+exports.startServer = (port = 3333, path = '.') ->
+  try
+    server = require sysPath.resolve 'server.coffee'
+    server.startServer( port, path, express, @)
+  catch error
+    exports.logError "[Brunch]: couldn\'t load server.coffee. #{error}"
+    exports.exit()
 
 exports.loadConfig = (configPath) ->
   try

--- a/template/base/server.coffee
+++ b/template/base/server.coffee
@@ -1,0 +1,12 @@
+exports.startServer = (port, path, express, helpers, callback = (->)) ->
+  server = express.createServer()
+  server.configure ->
+    server.use express.static path
+    server.set 'views', path
+    server.set 'view options', layout: no
+    server.register '.html', compile: (str, options) -> (locals) -> str
+  server.get '/', (req, res) ->
+    res.render 'index.html'
+  server.listen parseInt port, 10
+  server.on 'listening', callback
+  helpers.log "[Brunch]: application starting on http://0.0.0.0:#{port}."


### PR DESCRIPTION
As mentioned in the https://github.com/brunch/brunch/issues/188#issuecomment-3685951 I've extracted the startServer function into a separate file.

If the server.coffee file is unchanged, it will have the same functionality as before.

This feature will replace the old watch --server. 
