### PR TITLE
Move 'build' to rails/express 'public' naming convention, Fixes #177

### DIFF
--- a/src/brunch.coffee
+++ b/src/brunch.coffee
@@ -46,7 +46,7 @@ config.files['#{destinationPath}'].languages['#{regExp}']: #{error}.
 # 
 # Returns `fs_utils.FSWatcher` object.
 watchApplication = (rootPath, config, persistent, callback) ->
-  config.buildPath ?= sysPath.join rootPath, 'build'
+  config.buildPath ?= sysPath.join rootPath, 'public'
   config.server ?= {}
   config.server.port ?= 3333
 

--- a/template/base/config.coffee
+++ b/template/base/config.coffee
@@ -3,6 +3,9 @@
 # Make config loadable via require() for brunch.
 # See config docs at http://brunch.readthedocs.org/en/latest/config.html.
 exports.config =
+  # Uncomment and edit the next line to change default build path
+  # buildPath: 'public'
+
   # Edit this to change extension & content of files, created by
   # `brunch generate`.
   defaultExtensions:
@@ -14,7 +17,7 @@ exports.config =
   # List of included languages:
   # http://brunch.readthedocs.org/en/latest/plugins.html#default-languages
   files:
-    'scripts/app.js':
+    'javascripts/app.js':
       languages:
         '\\.js$': languages.JavaScriptLanguage
         '\\.coffee$': languages.CoffeeScriptLanguage


### PR DESCRIPTION
Hey Paul,

Not sure if this is what you had in mind for #177, but I think adding the comment to config.coffee makes it clearer that people can switch the build directory quite easily.
