### PR TITLE
Fix an error when requiring custom server script

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -68,7 +68,7 @@ startDefaultServer = (port, path, callback) ->
 exports.startServer = (config, callback = (->)) ->
   if config.server.path
     try
-      server = require sysPath.resolve config.paths.server
+      server = require sysPath.resolve config.server.path
       server.startServer config.server.port, config.paths.public, callback
     catch error
       logger.error "couldn\'t load server #{config.server.path}: #{error}"


### PR DESCRIPTION
Custom server scripts fails to load because it can't require the server script. This patch pass the correct file path to the require method.
