### PR TITLE
remove normalize when iterating array in _ignored

### DIFF
--- a/src/fs_utils/file_list.coffee
+++ b/src/fs_utils/file_list.coffee
@@ -28,7 +28,7 @@ module.exports = class FileList extends EventEmitter
       when '[object String]'
         helpers.startsWith(sysPath.normalize(path), sysPath.normalize(test))
       when '[object Array]'
-        test.some((subTest) => @_ignored path, sysPath.normalize(subTest))
+        test.some((subTest) => @_ignored path, subTest)
       else
         no
 


### PR DESCRIPTION
I wasn't thinking when I added the normalize there the first time. If you try to pass an `Array` with `RegEx`s or `Function`s it will run normalize on them which will convert them to strings. It's redundant for `Strings` too because they'll get normalized the second time through `_ignored`.

```
sysPath.normalize(function(){}) ==> 'function (){}'
sysPath.normalize(/foo/) ==> '/foo/'
```

so if you set

```
paths:
    ignored: [
        /some_reg_ex/,
        "/some/path/",
        (path)-> true
    ]
```

it would be teated as

```
paths:
    ignored: [
        "/some_reg_ex/",
        "/some/path/",
        "function(path){ return true; }"
    ]
```
