### PR TITLE
allow overriding mocha test reporter setting

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -134,6 +134,11 @@ the server would run'
           help: 'path to config file'
           metavar: 'CONFIG'
           full: 'config'
+        reporter:
+          abbr: 'r'
+          help: 'mocha reporter'
+          metavar: 'REPORTER'
+          full: 'reporter'
       callback: commands.test
       
   options:

--- a/src/commands/test.coffee
+++ b/src/commands/test.coffee
@@ -30,7 +30,7 @@ loadJsdom = ->
     process.exit 1
 
 class BrunchTestRunner
-  constructor: (options) ->
+  constructor: (@options) ->
     @config = helpers.loadConfig options.configPath
     @testFiles = helpers.findTestFiles @config
 
@@ -68,7 +68,7 @@ class BrunchTestRunner
 
     mocha = new Mocha()
     mocha
-      .reporter(@config.test?.reporter ? 'spec')
+      .reporter(@options.reporter or @config.test?.reporter or 'spec')
       .ui(@config.test?.ui ? 'bdd')
     @testFiles.forEach (file) =>
       mocha.addFile file


### PR DESCRIPTION
A bit too late for the 1.3 release, but anyway.

Now the continuous integration users can setup e.g. teamcity to run `brunch test --reporter teamcity`.
