### PR TITLE
fix local jsdom-installing-method

### DIFF
--- a/src/commands/test.coffee
+++ b/src/commands/test.coffee
@@ -35,11 +35,18 @@ b) Install jsdom locally for this project:
 """
 
 loadJsdom = ->
-  try
-    require 'jsdom'
-  catch error
+  safeRequire = (module) ->
+    try
+      require module
+    catch error
+      null
+
+  jsdom = safeRequire('jsdom') or safeRequire(sysPath.resolve('./node_modules/jsdom'))
+
+  unless jsdom
     showJsdomNote()
     process.exit 1
+  jsdom
 
 class BrunchTestRunner
   constructor: (@config, @options) ->


### PR DESCRIPTION
Since the `require('jsdom')` code gets called inside the brunch package, node looks in `brunch/node_modules` directory.

But it should look inside the user's application/package to check if jsdom is installed locally.
