### PR TITLE
Make test helper file detection RegEx less strict

### DIFF
--- a/src/commands/test.coffee
+++ b/src/commands/test.coffee
@@ -106,7 +106,7 @@ findTestHelpersFile = (testPath, callback) ->
     throw error if error?
     
     testHelpers = files.filter (file) ->
-      /^test-helpers\./.test file
+      /^test[-_]helper(s)?\./.test file
     
     if testHelpers.length > 0
       callback sysPath.resolve sysPath.join testPath, testHelpers[0]


### PR DESCRIPTION
Test helper file detection will now detect helper named either:
  test-helper
  test-helpers
  test_helper
  test_helpers
