### PR TITLE
Prepend “use strict” to wrapped modules by default.

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -323,7 +323,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
   modules              = config.modules      ?= {}
   modules.wrapper     ?= 'commonjs'
   modules.definition  ?= 'commonjs'
-  modules.strict      ?= yes
+  modules.strict      ?= no
 
   config.server       ?= {}
   config.server.base  ?= ''


### PR DESCRIPTION
Same as gh-412 but more robust and all Anthony’s work was squashed to one commit
