### PR TITLE
Ensure process returns 1 on compilation errors

### DIFF
--- a/src/commands/watch.coffee
+++ b/src/commands/watch.coffee
@@ -106,12 +106,16 @@ getCompileFn = (config, joinConfig, fileList, minifiers, watcher, callback) -> (
           logger.error subError
       else
         logger.error error
-      return
-    logger.info "compiled in #{Date.now() - startTime}ms"
+    else
+      logger.info "compiled in #{Date.now() - startTime}ms"
+
     unless config.persistent
       watcher.close()
       process.on 'exit', (previousCode) ->
         process.exit (if logger.errorHappened then 1 else previousCode)
+
+    if error?
+      return
 
     callback generatedFiles
 


### PR DESCRIPTION
Brunch returns too early before setting the process return code to an error (i.e. 1) in case compilation fails. In my case a Handlebars.js template failed to compile (syntax error).
