### PR TITLE
pass config to custom server

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -166,7 +166,7 @@ exports.startServer = (config, callback = (->)) ->
   if config.server.path
     try
       server = require sysPath.resolve config.server.path
-      server.startServer port, publicPath, onListening
+      server.startServer port, publicPath, onListening, config
     catch error
       logger.error "couldn\'t load server #{config.server.path}: #{error}"
   else


### PR DESCRIPTION
I've set up a `server.coffee` which I want to be configurable via `config.coffee`. However, the `config` variable is not passed to the `#startServer` method.

**My use case:**

[server.coffee](https://gist.github.com/3975644)

`config.coffee`:

```
server:
  path: 'server.coffee'
  port: 3333
  run: yes
  routes: [
    { host: '127.0.0.1', port: 80, re: /\/frameblocks\/[^\.]*\.json/ } # apache redirect
  ]
```
