### PR TITLE
make test work with dashes and underscores (in branch 1.4)

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -310,7 +310,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
   conventions.assets  ?= /assets(\/|\\)/
   conventions.ignored ?= paths.ignored ? (path) ->
     startsWith sysPath.basename(path), '_'
-  conventions.tests   ?= /_test\.\w+$/
+  conventions.tests   ?= /[-_]test\.\w+$/
   conventions.vendor  ?= /vendor(\/|\\)/
 
   config.notifications ?= on


### PR DESCRIPTION
It seems brunch 1.4 was left out of an update, so the tests in brunch-with-chaplin don't work.

For example this works with brunch 1.5 but not with brunch 1.4:

> > brunch new breakfast && cd breakfast
> > brunch test
> > 0 tests complete (0 ms) !!

It can't find the tests because they have been changed to home-page-view.coffee from home_page_view.coffee in the brunch-with-chaplin repo. So this will make 1.4 compatible with the new templates.
