### PR TITLE
when generating, don't overwrite files

### DIFF
--- a/src/commands/scaffold.coffee
+++ b/src/commands/scaffold.coffee
@@ -12,16 +12,21 @@ logger = require '../logger'
 fs_utils = require '../fs_utils'
 
 generateFile = (path, data, callback) ->
-  parentDir = sysPath.dirname path
-  write = ->
-    logger.info "create #{path}"
-    fs.writeFile path, data, callback
-  fs_utils.exists parentDir, (exists) ->
-    return write() if exists
-    logger.info "init #{parentDir}"
-    mkdirp parentDir, 0o755, (error) ->
-      return logger.error if error?
-      write()
+  fs_utils.exists path, (exists) ->
+    if exists
+      logger.info "skipping #{path} (already exists)"
+      callback() if callback?
+    else
+      parentDir = sysPath.dirname path
+      write = ->
+        logger.info "create #{path}"
+        fs.writeFile path, data, callback
+      fs_utils.exists parentDir, (exists) ->
+        return write() if exists
+        logger.info "init #{parentDir}"
+        mkdirp parentDir, 0o755, (error) ->
+          return logger.error if error?
+          write()
 
 destroyFile = (path, callback) ->
   fs.unlink path, (error) ->


### PR DESCRIPTION
Say you have a view generator with a template dependency:

```
{
  "files": [
    { "from": "view.js.hbs", "to": "app/views/{{name}}.js" }
  ],
  "dependencies": [
    { "name": "template", "params": "{{name}}" }
  ]
}
```

If a template with that name already exists, it gets overwritten.
