### PR TITLE
add a noSlashName property to generator template data

### DIFF
--- a/src/commands/scaffold.coffee
+++ b/src/commands/scaffold.coffee
@@ -113,7 +113,7 @@ generateFiles = (rollback, generatorsPath, type, templateData, callback) ->
 module.exports = scaffold = (rollback, options, callback = (->)) ->
   {type, name, pluralName, parentDir, configPath} = options
   pluralName = inflection.pluralize name
-  noSlashName = name.replace /(\/|\\)/g, '_'
+  strippedName = name.replace /(\/|\\)/g, '_'
 
   helpers.loadPackages helpers.pwd(), (error, packages) ->
     return logger.error error if error?
@@ -121,7 +121,7 @@ module.exports = scaffold = (rollback, options, callback = (->)) ->
     return callback() unless config?
 
     generators = config.paths.generators
-    templateData = {name, pluralName, noSlashName}
+    templateData = {name, pluralName, strippedName}
 
     generateFiles rollback, generators, type, templateData, parentDir, (error) ->
       return logger.error error if error?


### PR DESCRIPTION
Use case

`generators/route/route.hbs.js`

```
var App = require('app');

App.{{#camelize}}{{noSlashName}}{{/camelize}}Route = Em.Route.extend({});
```

`generators/route/generator.json`

``` json
{
  "files": [
    {
      "from": "route.js.hbs",
      "to": "app/routes/{{name}}.js"
    }
  ],
  "dependencies": []
}
```
### cli

``` bash
brunch g route foo/bar/baz
```
### output

`app/routes/foo/bar/baz.js`

``` javascript
var App = require('app');

App.FooBarBazRoute = Em.Route.extend({});
```
