### PR TITLE
prevent watch crash after npm install w/ custom config.paths

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -214,7 +214,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
 
   paths.assets        ?= join('app', 'assets')
 
-  paths.config         = configPath       ? joinRoot 'config'
+  paths.config        ?= configPath       ? joinRoot 'config'
   paths.packageConfig ?= joinRoot 'package.json'
 
   conventions          = config.conventions  ?= {}


### PR DESCRIPTION
Confirmed this change prevents the crash described in #534 when applied against 1.6.3.

Current master not working for me in general for unrelated reasons.
