### PR TITLE
Fix vendor file scope with addSourceURLs=true

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -152,7 +152,7 @@ commonJsWrapper = (addSourceURLs = no) -> (fullPath, fileData, isVendor) ->
   if isVendor
     # Simply execute vendor files.
     if addSourceURLs
-      "Function(#{data}).call(this);\n"
+      "eval(#{data});\n"
     else
       "#{data};\n"
   else


### PR DESCRIPTION
When addSourceURLs is enabled with the CommonJS wrapper, vendor files get wrapped in a closure which breaks certain libraries during debugging (e.g. new Handlebars runtime included in handlebars-brunch).

Switch to eval from Function so vendor files are executed in the same scope for both debug and production.
