### PR TITLE
fix source maps for non-commonjs configurations

### DIFF
--- a/src/fs_utils/source_file.coffee
+++ b/src/fs_utils/source_file.coffee
@@ -71,7 +71,13 @@ updateCache = (realPath, cache, error, result, wrap) ->
 
     cache.node.source = realPath
     cache.node.setSourceContent realPath, source
-    cache.node = wrap cache.node
+    
+    wrapped = wrap compiled
+    sourcePos = wrapped.indexOf compiled
+    if sourcePos > 0
+      cache.node.prepend wrapped.slice 0, sourcePos - 1
+      cache.node.add wrapped.slice sourcePos + compiled.length
+
   cache
 
 makeWrapper = (wrapper, path, isWrapped, isntModule) ->

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -136,32 +136,26 @@ exports.identityNode = (code, source) ->
   new SourceNode 1, 0, null, code.split('\n').map (line, index) ->
     new SourceNode index + 1, 0, source, (line + '\n')
 
-indent = (js) ->
-  # Emulate negative regexp look-behind a-la (?<!stuff).
-  js.replace /(\\)?\n(?!\n)/g, ($0, $1) ->
-    if $1 then $0 else '\n  '
-
 exports.cleanModuleName = cleanModuleName = (path) ->
   path
     .replace(new RegExp('\\\\', 'g'), '/')
     .replace(/^app\//, '')
 
-commonJsWrapper = (addSourceURLs = no) -> (fullPath, node, isVendor) ->
+commonJsWrapper = (addSourceURLs = no) -> (fullPath, data, isVendor) ->
   sourceURLPath = cleanModuleName fullPath
   moduleName = sourceURLPath.replace /\.\w+$/, ''
   path = JSON.stringify moduleName
 
   if isVendor
     debug 'commonjs wrapping is vendor '
-    node
+    data
   else
     # Wrap in common.js require definition.
-    prep = identityNode "window.require.register(#{path}, function(exports, require, module) {\n"
-    appe = identityNode "\n});\n"
-
-    pnode = new SourceNode
-    pnode.add [prep, node, appe]
-    pnode
+    """
+window.require.register(#{path}, function(exports, require, module) {
+#{data}
+});
+"""
 
 normalizeWrapper = (typeOrFunction, addSourceURLs) ->
   switch typeOrFunction
@@ -171,10 +165,10 @@ normalizeWrapper = (typeOrFunction, addSourceURLs) ->
         path = cleanModuleName fullPath
         """
 define('#{path}', ['require', 'exports', 'module'], function(require, exports, module) {
-  #{indent data}
+#{data}
 });
 """
-    when false then (path, data) -> "#{data}"
+    when false then (path, data) -> data
     else
       if typeof typeOrFunction is 'function'
         typeOrFunction
@@ -191,7 +185,7 @@ normalizeDefinition = (typeOrFunction) ->
         # store unique node in 'data' instead?
         node.prepend identityNode(data)
         node
-    when 'amd', false then -> (node) -> node
+    when 'amd', false then (node) -> node
     else
       if typeof typeOrFunction is 'function'
         typeOrFunction


### PR DESCRIPTION
this method allows custom wrapper functions to work the same way as before (i.e. without special source node handling)
