### PR TITLE
compilers must return {code, map} when sourcemap is enabled

### DIFF
--- a/src/fs_utils/generate.coffee
+++ b/src/fs_utils/generate.coffee
@@ -118,20 +118,15 @@ concat = (files, path, type, definition) ->
 
 minify = (data, smap, path, optimizer, isEnabled, callback) ->
   if isEnabled
-    debug 'minify ' + path
-    debug 'minify ' + data.length
     (optimizer.optimize or optimizer.minify) data, path, (error, result) ->
       if typeof result isnt 'string' # we have sourcemap
         {code, map} = result
         smConsumer = new SourceMapConsumer smap.toJSON()
-        debug smap.toJSON()
         map = SourceMapGenerator.fromSourceMap new SourceMapConsumer map
         map._sources.add path
         map._mappings.forEach (mapping) ->
           mapping.source = path
-        debug JSON.stringify map
         map.applySourceMap smConsumer
-        debug JSON.stringify map
         result = code
       callback error, result, map
   else

--- a/src/fs_utils/source_file.coffee
+++ b/src/fs_utils/source_file.coffee
@@ -46,7 +46,7 @@ pipeline = (realPath, path, linters, compiler, callback) ->
         # compiler is able to produce sourceMap
         if typeof compiledData is 'object'
           sourceMap = compiledData.map
-          compiled = compiledData.compiled
+          compiled = compiledData.code
         else
           compiled = compiledData
         getDependencies source, path, compiler, (error, dependencies) =>


### PR DESCRIPTION
like optimizers
instead of {compiled, map}

Removed also some useless debug logs
