### PR TITLE
Don't write sourceMap if disabled in config

### DIFF
--- a/src/fs_utils/generate.coffee
+++ b/src/fs_utils/generate.coffee
@@ -154,7 +154,7 @@ generate = (path, sourceFiles, config, minifiers, callback) ->
         data += "\n/*@ sourceMappingURL=#{base}*/"
 
     common.writeFile path, data, ->
-      if map and config.sourceMaps
+      if map and config.modules.sourceMaps
         common.writeFile "#{path}.map", map.toString(), callback
       else
         callback()


### PR DESCRIPTION
Sourcemaps are invalid if "modules.sourceMaps" are disabled so don't write it 
