### PR TITLE
Exposes loaded modules as globals.require.modules for testing convenience

### DIFF
--- a/vendor/require_definition.js
+++ b/vendor/require_definition.js
@@ -77,6 +77,6 @@
   globals.require.define = define;
   globals.require.register = define;
   globals.require.brunch = true;
-  globals.require.modules = modules;
+  globals.require.cache = modules;
 })();
 


### PR DESCRIPTION
This allows me to run all of the tests under the test/ directory by filename convention, rather than having to list them all.  Here's how that looks in my codebase 

tests/initialize.coffee:

```
tests = []

for module of window.require.modules
  tests.push module if module.substring(module.length - 5) is "_test"

for test in tests
  require test
```

tests/assets/test/index.html:

```
...
<script src="javascripts/test.js"></script>
<script>
  $(function() {
      require('test/initialize');
      if (window.mochaPhantomJS) { mochaPhantomJS.run(); }
      else { mocha.run().globals(['selector', 'FB', 'fbAsyncInit']); }
  });
</script>
...
```
