### PR TITLE
Eliminates IE 8 stack overflow

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -152,7 +152,7 @@ commonJsWrapper = (addSourceURLs = no) -> (fullPath, data, isVendor) ->
   else
     # Wrap in common.js require definition.
     """
-window.require.register(#{path}, function(exports, require, module) {
+window.globals.require.register(#{path}, function(exports, require, module) {
 #{data}
 });
 """

--- a/vendor/require_definition.js
+++ b/vendor/require_definition.js
@@ -1,7 +1,14 @@
 (function(/*! Brunch !*/) {
   'use strict';
 
-  var globals = typeof window !== 'undefined' ? window : global;
+  var globals = {}
+  if (typeof window === 'undefined') {
+    globals = global;
+  } else if (typeof window.globals !== 'undefined') {
+    globals = window.globals;
+  } else {
+    window.globals = globals;
+  }
   if (typeof globals.require === 'function') return;
 
   var modules = {};


### PR DESCRIPTION
Internet Explorer 8 has a limitation whereby a given call stack for a function that's attached to 'window' can only contain that function at most 13 times before IE gives a "Stack overflow  at line 0" error.

We ran into this with Brunch because require() is hanging off of window and we have items in our UI that are more than 13 levels deep into the require() stack.

Here is a JSFiddle that demonstrates the issue:   http://jsfiddle.net/4Ms8p/3/.  If you run this fiddle in its current state in IE 8 then you'll see an alert with "Foo is bar and bar is [Object object]".  However, if you uncomment line 152 ("mybar = require('bar13');"), then it will additionally show an alert saying "Stack overflow at line 0".

Seems that IE only has an issue on functions that are directly attached to 'window', so my approach to solving this for now was to make an object on window called 'globals', and attach the require() function there.
