### PR TITLE
Fixing Vendor and Asset Conventions

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -218,7 +218,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
   conventions.ignored ?= paths.ignored ? (path) ->
     sysPath.basename(path)[0] is '_'
   conventions.tests   ?= /[-_]test\.\w+$/
-  conventions.vendor  ?= /(components|vendor)[\\/]/
+  conventions.vendor  ?= /(^components|vendor)[\\/]/
 
   config.notifications ?= true
   config.sourceMaps   ?= true


### PR DESCRIPTION
fixing conventions so that folders within the project (not at the top level) with a name of components or vendor or assets don't get treated differently.
