### PR TITLE
Allow arbitrary options to be passed to pushserve

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -52,6 +52,7 @@ generateParams = (persistent, options) ->
   params
 
 startServer = (config, callback = (->)) ->
+  serverOpts = config.server or {}
   port = parseInt config.server.port, 10
   publicPath = config.paths.public
   log = ->
@@ -66,7 +67,8 @@ startServer = (config, callback = (->)) ->
       throw new Error 'Brunch server file needs to have startServer function'
     server.startServer port, publicPath, log
   else
-    pushserve {port, path: publicPath, base: config.server.base, noLog: true}, log
+    opts = noLog: yes, path: publicPath
+    pushserve helpers.extend(opts, serverOpts), log
 
 # Filter paths that exist and watch them with `chokidar` package.
 #


### PR DESCRIPTION
Could also be leveraged to pass additional options to custom servers using `server.path`.

This was added to support the `stripSlashes` option in pushserve https://github.com/paulmillr/pushserve/pull/1
