### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "async-waterfall": "~0.1.0"
   },
   "devDependencies": {
-    "mocha": "~1.11.0",
+    "mocha": "~1.12.0",
     "chai": "~1.7.0",
     "express": "~3.3.0"
   }


### PR DESCRIPTION
mocha-phantomjs@3.1.0 is not backwards compatible under mocha.js@1.12.0
See: https://github.com/metaskills/mocha-phantomjs/pull/74
