### PR TITLE
Let local brunch installation take precedence

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -3,5 +3,10 @@
 var path = require('path');
 var fs = require('fs');
 
-var src = path.join(path.dirname(fs.realpathSync(__filename)), '..', 'lib');
-require(path.join(src, 'cli')).run();
+try {
+  var localCli = path.join(path.resolve('.'), 'node_modules', 'brunch', 'lib', 'cli');
+  require(localCli).run();
+} catch (e) {
+  var globalCli = path.join(path.dirname(fs.realpathSync(__filename)), '..', 'lib', 'cli');
+  require(globalCli).run();
+}


### PR DESCRIPTION
Seems to work fine. What could go wrong?

I left `brunchcoffee` alone on purpose...
