### PR TITLE
Fix Win32 compilation error

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -83,6 +83,8 @@ exports.replaceConfigSlashes = replaceConfigSlashes = (config) ->
 
     # Modify order.
     Object.keys(order).forEach (orderKey) ->
+      if typeof lang.order[orderKey] == 'string'
+        lang.order[orderKey] = [ lang.order[orderKey] ]
       lang.order[orderKey] = lang.order[orderKey].map(replaceSlashes)
 
     # Modify join configuration.


### PR DESCRIPTION
Without this change, we see the following error trace on a fresh checkout of http://github.com/g0v/ivod.ly.g0v.tw/ on Windows 8, Node 0.10 with `npm i; npm start`.

```
> ly.g0v.tw@0.1.1 start C:\Users\Audrey\Documents\GitHub\ivod.ly.g0v.tw
> brunch watch --server


TypeError: Object app/app/controllers.ls has no method 'map'
    at C:\Users\Audrey\Documents\GitHub\ivod.ly.g0v.tw\node_modules\brunch\lib\helpers.js:90:60
    at Array.forEach (native)
    at C:\Users\Audrey\Documents\GitHub\ivod.ly.g0v.tw\node_modules\brunch\lib\helpers.js:88:26
    at Array.forEach (native)
    at exports.replaceSlashes.replaceSlashes (C:\Users\Audrey\Documents\GitHub\ivod.ly.g0v.tw\node_modules\brunch\lib\he
lpers.js:83:24)
```

Reported by @OtomeSound in http://logbot.g0v.tw/channel/g0v.tw/2013-11-06/334
