### PR TITLE
Ultra-flexible config matching and sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "commonjs-require-definition": "~0.1.0",
     "async-each": "~0.1.2",
     "async-waterfall": "~0.1.2",
-    "anymatch": "~0.1.0",
     "anysort": "~0.1.0"
   },
   "devDependencies": {

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -333,11 +333,24 @@ exports.loadConfig = (configPath = 'brunch-config', options = {}, callback) ->
       logger.error error
     bowerComponents ?= []
     config._normalized.bowerComponents = bowerComponents
+
+    config._normalized.bowerOrder = bowerComponents
+      .sort (a, b) ->
+        if a.sortingLevel is b.sortingLevel
+          if a.files[0] < b.files[0] then -1 else 1
+        else
+          b.sortingLevel - a.sortingLevel
+      .reduce (flat, component) ->
+        flat.concat component.files
+      , []
+
+    ### TO BE REMOVED ###
     filesMap = config._normalized.bowerFilesMap = {}
     bowerComponents.forEach (component) ->
       filesLength = component.files.length
       component.files.forEach (file, index) ->
         filesMap[file] = component.sortingLevel + (filesLength * 0.001 - index * 0.001)
+    ### /TO BE REMOVED ###
 
     deepFreeze config
     callback null, config


### PR DESCRIPTION
Not to be merged as-is

This PR includes both the original way and new way of setting concatenation order, and will print a message to stdout it they don't match. It skips this if any globs or non-strings are included in an order definition. Hoping to get a lot of participation in testing this against various projects to look for edge cases.

I've already checked it with several popular skeletons and my own large project.

What this does is allows more ways to define file lists in parts of the config, such as `joinTo` that used to only accept regexes or functions (strings, globs, array of any combo). Similarly, the `before` and `after` arrays under `order` can now use globs, regexes and functions in addition to strings.

To try it out, do `npm install -g https://github.com/brunch/brunch/tarball/anysort`, then use brunch on your projects as before. Please report any 'Sorting mismatch' messages or errors. Also, try using arrays and/or globs in your `joinTo` and/or `conventions` config as well as globs/regexes in your `order` arrays.

Resolves #674.
Resolves part of #616.
