### PR TITLE
Permit linting errors to be Error objects

### DIFF
--- a/src/fs_utils/pipeline.coffee
+++ b/src/fs_utils/pipeline.coffee
@@ -70,7 +70,7 @@ pipeline = (path, linters, compilers, callback) ->
     return callback throwError 'Reading', error if error?
     debug "Linting '#{path}'"
     lint source, path, linters, (error) ->
-      if error?.match /^warn\:\s/i
+      if error?.toString().match /^warn\:\s/i
         logger.warn "Linting of #{path}: #{error}"
       else
         return callback throwError 'Linting', error if error?


### PR DESCRIPTION
This corrects the implicit assumption that errors returned from linting are strings by converting to string explicitly. In the case of `coffeelint-brunch`, a `SyntaxError` object returned by the linter causes brunch to crash with a `TypeError`. With this patch in place, the `TypeError` no longer occurs.
