### PR TITLE
Fix heroku deployment with ruby env

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -223,6 +223,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
   conventions.ignored ?= paths.ignored ? [
     /[\\/]_/
     /vendor[\\/]node[\\/]/
+    /vendor[\\/]bundle[\\/]/
   ]
   conventions.vendor  ?= /(^bower_components|vendor)[\\/]/
 


### PR DESCRIPTION
Working on a brunch project that includes sass and therefore ruby. Upon deploying to heroku, brunch-sass attempts to compile the ruby gem sass source files in vendor/bundle and fails. This is very related to:
https://github.com/brunch/uglify-js-brunch/issues/15

This change resolves the issue and allows for deployment of a ruby / node environment on heroku.
