### PR TITLE
Early logger initialization.

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -331,6 +331,8 @@ initialize = (options, configParams, onCompile, callback) ->
 
   # Load config, get brunch packages from package.json.
   helpers.loadConfig options.config, configParams, (error, config) ->
+    logger.notifications = @config.notifications
+    logger.notificationsTitle = @config.notificationsTitle or 'Brunch'
     joinConfig = config._normalized.join
     plugins    = getPlugins packages, config
 
@@ -446,8 +448,6 @@ class BrunchWatcher
     initialize options, configParams, onCompile, (error, result) =>
       return logger.error error if error?
       {@config, watcher, fileList, compilers, linters, compile, reload, includes} = result
-      logger.notifications = @config.notifications
-      logger.notificationsTitle = @config.notificationsTitle or 'Brunch'
       if @config.workers?.enabled
         return unless worker {changeFileList, compilers, linters, fileList, @config}
 


### PR DESCRIPTION
The initialization of logger moved into `initialize` area of the watcher because the logger configuration was loaded too late in case of `-s`
