### PR TITLE
Bug using an inexistent context

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -331,8 +331,8 @@ initialize = (options, configParams, onCompile, callback) ->
 
   # Load config, get brunch packages from package.json.
   helpers.loadConfig options.config, configParams, (error, config) ->
-    logger.notifications = @config.notifications
-    logger.notificationsTitle = @config.notificationsTitle or 'Brunch'
+    logger.notifications = config.notifications
+    logger.notificationsTitle = config.notificationsTitle or 'Brunch'
     joinConfig = config._normalized.join
     plugins    = getPlugins packages, config
 


### PR DESCRIPTION
With apologies, I've kept by mistake the `@` (this) where doesn't exist
