### PR TITLE
recompile parents of dependent file always, not only if it doesn't have compiler

### DIFF
--- a/src/fs_utils/file_list.coffee
+++ b/src/fs_utils/file_list.coffee
@@ -134,10 +134,9 @@ module.exports = class FileList extends EventEmitter
       unless ignored
         @copy (@findAsset(path) ? @_addAsset path)
     else
-      if ignored or not compiler?.length
-        @compileDependencyParents path unless @initial
-      else
+      if not ignored and compiler?.length
         @compile (@find(path) ? @_add path, compiler, linters, isHelper)
+      @compileDependencyParents path unless @initial
 
   _unlink: (path) ->
     ignored = @isIgnored path


### PR DESCRIPTION
CSS preprocessors, like LESS or SASS has @import directive, and if these dependency files located in the same folder that parents (say, "./less"), brunch doesn't recompile parent less files, which is specified in brunch-config.coffee if it's dependencies changed. In brunch-config used only parent files, that only import necessary files
