### PR TITLE
Fall back to empty object if project has no dependencies

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -331,7 +331,7 @@ loadPackages = (rootPath, callback) ->
             requireModule depPath, dependency
           catch error
             throw new Error "You probably need to execute `npm install` to install brunch plugins. #{error}"
-  plugins = loadDeps(Object.keys json.dependencies)
+  plugins = loadDeps(Object.keys json.dependencies or {})
   devPlugins = loadDeps(Object.keys(json.devDependencies or {}), true)
   plugins.concat(devPlugins.filter((_) -> _?))
 


### PR DESCRIPTION
Some projects have no dependencies, but only devDependencies. In these projects, brunch fails because of 

```
/var/www/jimdo/prod/node_modules/brunch/lib/watch.js:403
    plugins = loadDeps(Object.keys(json.dependencies));
                              ^
TypeError: Object.keys called on non-object
  at Function.keys (native)
  at loadPackages (/var/www/jimdo/prod/node_modules/brunch/lib/watch.js:403:31)
  at /var/www/jimdo/prod/node_modules/brunch/lib/watch.js:422:19
  at /var/www/jimdo/prod/node_modules/brunch/lib/helpers.js:498:16
  at /var/www/jimdo/prod/node_modules/brunch/lib/helpers.js:457:14
  at /var/www/jimdo/prod/node_modules/brunch/node_modules/read-components/index.js:240:16
  at /var/www/jimdo/prod/node_modules/brunch/node_modules/read-components/index.js:54:14
  at Object.cb [as oncomplete] (fs.js:168:19)
```

This PR fixes this.
