### PR TITLE
sort input files like they were defined in joinTo

### DIFF
--- a/src/fs_utils/write.coffee
+++ b/src/fs_utils/write.coffee
@@ -4,9 +4,12 @@ each = require 'async-each'
 sysPath = require 'path'
 generate = require './generate'
 helpers = require '../helpers'
+anysort = require 'anysort'
+
+typeToGroup = (type) -> "#{type}s"
 
 getPaths = (sourceFile, joinConfig) ->
-  sourceFileJoinConfig = joinConfig[sourceFile.type + 's'] or {}
+  sourceFileJoinConfig = joinConfig[typeToGroup sourceFile.type] or {}
   Object.keys(sourceFileJoinConfig)
     .filter (key) ->
       key isnt 'pluginHelpers'
@@ -26,6 +29,10 @@ getFiles = (fileList, config, joinConfig) ->
     paths.forEach (path) ->
       map[path] ?= []
       map[path].push file
+
+  for path, sourceFiles of map
+    sourceFiles.sort (a, b) ->
+      anysort a.path, b.path, config.files[typeToGroup a.type].joinTo[path]
 
   Object.keys(map).map (generatedFilePath) ->
     sourceFiles = map[generatedFilePath]


### PR DESCRIPTION
This is the first direction into stabilizing the input order of files.
Currently, files in joinTo are ordered alphabetically before being concatenated.

A second commit would fix [`sortByConfig`](https://github.com/brunch/brunch/blob/master/src/fs_utils/generate.coffee#L20) to not destroy the input order of the files given. This fix however probably needs to be made in [anysort](https://github.com/es128/anysort)

Closes #825
