### PR TITLE
Only add trailing semicolon if source file does not have one already

### DIFF
--- a/src/fs_utils/generate.coffee
+++ b/src/fs_utils/generate.coffee
@@ -66,8 +66,8 @@ concat = (files, path, type, definition, aliases) ->
   debug "Concatenating #{files.map((_) -> _.path).join(', ')} to #{path}"
   files.forEach (file) ->
     root.add file.node
-    root.add ';' if type is 'javascript'
     data = if file.node.isIdentity then file.data else file.source
+    root.add ';' if type is 'javascript' and ';' isnt data.trim().substr -1
     root.setSourceContent file.node.source, data
 
   root.prepend definition(path, root.sourceContents) if type is 'javascript'


### PR DESCRIPTION
A trailing semicolon only needs to be added if the source file does not have one already, e.g.
input like `a.js` with `var a = true;` and `b.js` with `var b = true;` ends up being

``` javascript
var a = true;

;var b = true;

;
```

instead of

``` javascript
var a = true;

var b = true;
```

This PR fixes this.
