### PR TITLE
Only replaceSlashes for strings

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -75,11 +75,12 @@ exports.install = install = (rootPath, command, callback = (->)) ->
 
 exports.isWindows = isWindows = do -> os.platform() is 'win32'
 
-exports.replaceSlashes = replaceSlashes = (_) ->
-  if isWindows then _.replace(/\//g, '\\') else _
+windowsStringReplace = (search, replacement) -> (_) ->
+  if isWindows && typeof _ is 'string' then _.replace(search, replacement) else _
+    
+exports.replaceSlashes = replaceSlashes = windowsStringReplace(/\//g, '\\')
 
-exports.replaceBackSlashes = replaceBackSlashes = (_) ->
-  if isWindows then _.replace(/\\/g, '\/') else _
+exports.replaceBackSlashes = replaceBackSlashes = windowsStringReplace(/\\/g, '\/')
 
 exports.replaceConfigSlashes = replaceConfigSlashes = (config) ->
   return config unless isWindows

--- a/test/fixtures/unix_config.coffee
+++ b/test/fixtures/unix_config.coffee
@@ -23,7 +23,7 @@ exports.config =
           'vendor/scripts/console-helper.js',
           'vendor/scripts/jquery-1.7.2.js',
           'vendor/scripts/underscore-1.3.1.js',
-          'vendor/scripts/backbone-0.9.2.js'
+          /backbone-0.9.2.js/
         ]
 
     stylesheets:

--- a/test/fixtures/win_config.coffee
+++ b/test/fixtures/win_config.coffee
@@ -23,7 +23,7 @@ exports.config =
           'vendor\\scripts\\console-helper.js',
           'vendor\\scripts\\jquery-1.7.2.js',
           'vendor\\scripts\\underscore-1.3.1.js',
-          'vendor\\scripts\\backbone-0.9.2.js'
+          /backbone-0.9.2.js/,
         ]
 
     stylesheets:


### PR DESCRIPTION
Caused an error on Windows when 'order' contained a RegEx.

I changed test fixture configs to include a regex, which would cause the test to then fail on Windows.
