### PR TITLE
Remove leading ../ characters from paths.

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -192,9 +192,10 @@ exports.identityNode = (code, source) ->
     new SourceNode index + 1, 0, source, (line + '\n')
 
 exports.cleanModuleName = cleanModuleName = (path, nameCleaner) ->
-  nameCleaner path
+  nameCleaner(path
     .replace(new RegExp('\\\\', 'g'), '/')
     .replace(new RegExp('^(\.\.\/)*', 'g'), '')
+  )
 
 getModuleWrapper = (type, nameCleaner) -> (fullPath, data, isVendor) ->
   sourceURLPath = cleanModuleName fullPath, nameCleaner


### PR DESCRIPTION
Hopefully this is fine to merge in; I can't think of any use cases where it may be a breaker.

Based on this issue I had:
http://stackoverflow.com/questions/26301406/brunch-requiring-modules-outside-of-app-directory

In order to be able to require any modules that are outside Brunch's own root, I had to add `../path` to my watched files in the config. However, require doesn't seem to like the parent folder symbol (for want of a better name), so I've changed it so that it'll strip off any leading `../`s from the path.

Thoughts?
Cheers, Matt.
