### PR TITLE
Add more documentation on notification config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -165,7 +165,13 @@ plugins:
            [terminal-notifier](https://github.com/alloy/terminal-notifier#download) /
            [libnotify for Ubuntu](http://packages.ubuntu.com/search?keywords=libnotify-bin)
            notifications.
-           Default value is `true` (enabled).
+           Default value is `true` (enabled).  
+
+When set to `true`, only errors trigger notifications. If you want to display success, warning, or informational messages, set this to an array of strings with the levels you want to see, e.g. `['error', 'warn', 'info']`. See [documentation for the Loggy package](https://github.com/paulmillr/loggy) for complete details.
+
+## `notificationsTitle`
+
+`String`: sets the title used in notifications. Default value is `Brunch`. [The notifications setting](#notifications) must be enabled for this to have any effect.
 
 ## `optimize`
 


### PR DESCRIPTION
The notification documentation was a little incomplete (and thus confusing) with respect to how it works. I fleshed it out a little bit. It would make sense to leave this undocumented if you don't like how the more extensive configuration works in loggy, but if so I'd recommend an alternate change of forcing the config to be a boolean in the brunch config loader.
