### PR TITLE
Exit watcher when stdin is closed

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -480,6 +480,9 @@ bindWatcherEvents = (config, fileList, compilers, linters, watcher, reload, onCh
     onChange()
     changeFileList compilers, linters, fileList, path, false
 
+  process.stdin.on 'end', -> process.exit(0)
+  process.stdin.resume()
+
   watcher
     .on('error', logger.error)
     .on 'add', (absPath) ->


### PR DESCRIPTION
This follows the footsteps of the node CLI and other Unix utilities