### PR TITLE
Only listen to stdin if in persistent mode

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -480,8 +480,9 @@ bindWatcherEvents = (config, fileList, compilers, linters, watcher, reload, onCh
     onChange()
     changeFileList compilers, linters, fileList, path, false
 
-  process.stdin.on 'end', -> process.exit(0)
-  process.stdin.resume()
+  if config.persistent
+    process.stdin.on 'end', -> process.exit(0)
+    process.stdin.resume()
 
   watcher
     .on('error', logger.error)


### PR DESCRIPTION
Otherwise brunch build will wait for stdin to be closed
too and it won't exit properly.