### PR TITLE
Implement node_modules support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pushserve": "~0.1.6",
     "read-components": "~0.6.0",
     "source-map": "~0.3.0",
-    "deppack": "~0.0.7"
+    "deppack": "~0.0.8"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,7 @@
     "pushserve": "~0.1.6",
     "read-components": "~0.6.0",
     "source-map": "~0.3.0",
-    "module-deps": "3.7.2",
-    "browser-pack": "4.0.0",
-    "JSONStream": "0.7.1",
-    "through": ">=2.2.7 <3",
-    "browser-resolve": "~1.7.2"
+    "deppack": "~0.0.5"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "source-map": "~0.3.0",
     "module-deps": "3.7.2",
     "browser-pack": "4.0.0",
-    "JSONStream": "0.7.1"
+    "JSONStream": "0.7.1",
+    "through": ">=2.2.7 <3",
+    "browser-resolve": "~1.7.2"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pushserve": "~0.1.6",
     "read-components": "~0.6.0",
     "source-map": "~0.3.0",
-    "deppack": "~0.0.5"
+    "deppack": "~0.0.7"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
     "ncp": "~1.0.1",
     "pushserve": "~0.1.6",
     "read-components": "~0.6.0",
-    "source-map": "~0.3.0"
+    "source-map": "~0.3.0",
+    "module-deps": "3.7.2",
+    "browser-pack": "4.0.0",
+    "JSONStream": "0.7.1"
   },
   "devDependencies": {
     "mocha": "~1.12.0",

--- a/src/fs_utils/pipeline.coffee
+++ b/src/fs_utils/pipeline.coffee
@@ -74,12 +74,12 @@ isNpm = (path) ->
 
 pipeline = (path, linters, compilers, callback) ->
   if isNpm path
-    deppack path, {basedir: '.', rollback: true}, (error, source) ->
+    deppack path, {basedir: '.', rollback: true, ignoreRequireDefinition: true}, (error, source) ->
       compile source, path, compilers, callback
   else
     fcache.readFile path, (error, source) =>
-      debug "Linting '#{path}'"
       lint source, path, linters, (error) ->
+        debug "Linting '#{path}'"
         if error?.toString().match /^warn\:\s/i
           logger.warn "Linting of #{path}: #{error}"
         else

--- a/src/fs_utils/pipeline.coffee
+++ b/src/fs_utils/pipeline.coffee
@@ -4,6 +4,9 @@ debug = require('debug')('brunch:pipeline')
 fcache = require 'fcache'
 sysPath = require 'path'
 logger = require 'loggy'
+deps = require 'module-deps'
+pack = require 'browser-pack'
+JSONStream = require 'JSONStream'
 
 throwError = (type, stringOrError) =>
   string = if stringOrError instanceof Error
@@ -68,7 +71,25 @@ compile = (source, path, compilers, callback) ->
   first = (next) -> next null, {source, path, callback}
   waterfall [first].concat(compilers.map mapCompilerChain), callback
 
+isNpm: (path) ->
+  path.indexOf('node_modules') >= 0
+
+readWithDeps: (src, cb) ->
+  srcPath = sysPath.join rootPath, 'node_modules', src
+  srcJson = require sysPath.join srcPath, 'package.json'
+  srcMain = srcJson.main || 'index.js'
+  md = deps()
+  pck = pack()
+  data = ''
+  md.pipe(JSONStream.stringify()).pipe(pck).pipe(process.stdout)
+  md.end({ file: rootPath + '/node_modules/' + src + '/' + srcMain})
+  md.on('end', -> cb(null, data))
+
+
 pipeline = (path, linters, compilers, callback) ->
+  # if isNpm(path)
+
+  # else
   fcache.readFile path, (error, source) =>
     debug "Linting '#{path}'"
     lint source, path, linters, (error) ->

--- a/src/fs_utils/pipeline.coffee
+++ b/src/fs_utils/pipeline.coffee
@@ -83,6 +83,7 @@ readWithDeps: (src, cb) ->
   data = ''
   md.pipe(JSONStream.stringify()).pipe(pck).pipe(process.stdout)
   md.end({ file: rootPath + '/node_modules/' + src + '/' + srcMain})
+  md.on 'finish',  -> console.log(123123)
   md.on('end', -> cb(null, data))
 
 

--- a/src/fs_utils/pipeline.coffee
+++ b/src/fs_utils/pipeline.coffee
@@ -73,9 +73,8 @@ isNpm = (path) ->
   path.indexOf('node_modules') >= 0
 
 pipeline = (path, linters, compilers, callback) ->
-  if isNpm(path)
-    deppack path, {basedir: '.'}, (err, source) ->
-      console.log path
+  if isNpm path
+    deppack path, {basedir: '.', rollback: true}, (error, source) ->
       compile source, path, compilers, callback
   else
     fcache.readFile path, (error, source) =>

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -12,13 +12,8 @@ debug = require('debug')('brunch:helpers')
 commonRequireDefinition = require 'commonjs-require-definition'
 anymatch = require 'anymatch'
 coffee = require 'coffee-script'
-deps = require 'module-deps'
-pack = require 'browser-pack'
-JSONStream = require 'JSONStream'
-through = require('through')
-browserResolve = require('browser-resolve')
-detective = require 'detective'
 each = require 'async-each'
+deppack = require 'deppack'
 coffee.register()
 
 # Extends the object with properties from another object.
@@ -266,7 +261,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
     /[\\/]_/
     /vendor[\\/](node|j?ruby-.*|bundle)[\\/]/
   ]
-  conventions.vendor  ?= /(^bower_components|vendor)[\\/]/
+  conventions.vendor  ?= /(^bower_components|node_modules|vendor)[\\/]/
 
   config.notifications ?= true
   config.sourceMaps   ?= true
@@ -371,106 +366,26 @@ loadComponents = (config, type, callback) ->
     callback {components, aliases, order}
 
 loadNpm = (config, cb) ->
-  rootPath = sysPath.resolve config.paths.root
-  jsonPath = sysPath.join(rootPath, 'package.json')
-  json = require(jsonPath)
-  Object.keys(json.dependencies).forEach (dep) ->
-    depPath = sysPath.join rootPath, 'node_modules', dep
-    depJson = require sysPath.join depPath, 'package.json'
-    depMain = depJson.main || 'index.js'
-    fullDepPath =  rootPath + '/node_modules/' + dep + '/' + depMain
-    load(fullDepPath, {}, (err, allFiles) ->
-      #console.log allFiles, 111
-    )
-    # md = new deps()
-    # results = []
-    # d = ''
-    # pk = pack()
-    # stream = through(((data) ->
-    #   #console.log 222
-    # ), (d) -> console.log(111))
-    # md.pipe(JSONStream.stringify()).pipe(pk)#.pipe(process.stdout)#.pipe stream#.pipe(pk).pipe(stream)#.pipe(stream)#.pipe(process.stdout)#.pipe(pk).pipe(process.stdout)
-    # d = ''
-    # md.on 'data', (da) ->
-    #   results.push da
-    # # console.log md
-    # # pk.on 'data', (data) -> console.log data
-    # #md.on 'end', -> console.log 'end'
-    # #md.on 'finish', -> console.log 'finish'
-    # md.on 'file', (filename) ->
-    #   # console.log d
-    #   md.end() if filename is 'path'
-    # md.end({ file: rootPath + '/node_modules/' + dep + '/' + depMain}, -> console.log 'END')
+  {paths} = config
+  rootPath = sysPath.resolve paths.root
+  jsonPath = sysPath.join(rootPath, paths.packageConfig)
+  try
+    json = require(jsonPath)
+  catch error
+    throw new Error "You probably need to execute `npm install` to install brunch plugins. #{error}"
+  items = Object.keys(json.dependencies)
+    .filter (dep) ->
+      dep isnt 'brunch' and dep.indexOf('brunch') is -1 and !anymatch(config.conventions.ignored, dep)
+    .map (dep) ->
+      depPath = sysPath.join rootPath, 'node_modules', dep
+      depJson = require sysPath.join depPath, 'package.json'
+      depMain = depJson.main || 'index.js'
+      file = 'node_modules/' + dep + '/' + depMain
+      name: dep
+      files: [file]
+      version: json.dependencies[dep]
+  cb components: items
 
-load = (filePath, opts, callback) ->
-  allFiles = []
-  cache = {}
-  visited = {}
-  basedir = opts.basedir or process.cwd()
-  paths = (opts.paths or process.env.NODE_PATH?.split(':') or [])
-    .map (path) => sysPath.resolve(basedir, path)
-
-  getModuleRootPath = (filePath) ->
-    pathArray = filePath.split('/')
-    rootIndex = pathArray.lastIndexOf('node_modules')
-    pathArray.slice(0, (rootIndex + 2)).join('/')
-
-  readFile = (filePath, cb) ->
-    fs.readFile filePath, encoding: 'utf8',(err, src) ->
-      cb err if err
-      cb null, src
-
-  getResolveFn = (resolved, parent) -> (dep) ->
-    if opts.ignore?(dep)
-      resolved[dep] = false
-    else
-      browserResolve dep, parent, (err, res) ->
-        resolved[dep] = res;
-
-  tryCallback = ->
-    if Object.keys(cache).every((key) -> cache[key])
-      console.log 'END!!!'
-      callback null, allFiles
-
-  loadDeps = (filePath) ->
-    cache[filePath] = false
-    modulePath = getModuleRootPath(filePath)
-
-    jsonPath = sysPath.join modulePath, 'package.json'
-    json = require jsonPath
-    jsonDeps = Object.keys(json.dependencies || {})
-
-    readFile filePath, (err, src) ->
-      callback err if err
-      deps = detective(src)
-      resolved = {}
-      item =
-        id: filePath
-        filename: filePath
-        paths: paths
-        package: json
-      getResult = ->
-        id: filePath
-        source: src
-        deps: resolved
-        file: filePath
-      if deps.length is 0
-        cache[filePath] = true
-        allFiles.push(getResult())
-        tryCallback()
-      else
-        itemHandler = (dep, cb) ->
-          browserResolve dep, item, (err, fullPath) ->
-            resolved[dep] = fullPath
-            cb null, fullPath
-
-        each deps, itemHandler, (err, fullPathDeps) ->
-          allFiles.push(getResult())
-          fullPathDeps.forEach (filePath) ->
-            loadDeps filePath
-          cache[filePath] = true
-
-  loadDeps(filePath)
 
 exports.loadConfig = (configPath = 'brunch-config', options = {}, callback) ->
   try
@@ -498,13 +413,13 @@ exports.loadConfig = (configPath = 'brunch-config', options = {}, callback) ->
   normalizeConfig config
   config._normalized.packageInfo = {}
 
-  loadNpm config, (bowerRes) ->
-    console.log bowerRes
+  loadNpm config, (npmRes) ->
+    config._normalized.packageInfo.npm = npmRes
 
-  loadComponents config, 'bower', (bowerRes)->
-    config._normalized.packageInfo.bower = bowerRes
+    loadComponents config, 'bower', (bowerRes)->
+      config._normalized.packageInfo.bower = bowerRes
 
-    loadComponents config, 'component', (componentRes) ->
-      config._normalized.packageInfo.component = componentRes
-      deepFreeze config
-      callback null, config
+      loadComponents config, 'component', (componentRes) ->
+        config._normalized.packageInfo.component = componentRes
+        deepFreeze config
+        callback null, config

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -12,6 +12,9 @@ debug = require('debug')('brunch:helpers')
 commonRequireDefinition = require 'commonjs-require-definition'
 anymatch = require 'anymatch'
 coffee = require 'coffee-script'
+deps = require 'module-deps'
+pack = require 'browser-pack'
+JSONStream = require 'JSONStream'
 coffee.register()
 
 # Extends the object with properties from another object.
@@ -363,6 +366,21 @@ loadComponents = (config, type, callback) ->
 
     callback {components, aliases, order}
 
+loadNpm = (config, cb) ->
+  rootPath = sysPath.resolve config.paths.root
+  jsonPath = sysPath.join(rootPath, 'package.json')
+  json = require(jsonPath)
+  Object.keys(json.dependencies)#.forEach (dep) ->
+    # depPath = sysPath.join rootPath, 'node_modules', dep
+    # depJson = require sysPath.join depPath, 'package.json'
+    # depMain = depJson.main || 'index.js'
+    # md = new deps()
+    # results = []
+    # pk = pack()
+    # md.pipe(JSONStream.stringify()).pipe(pk).pipe(process.stdout)
+    # md.end({ file: rootPath + '/node_modules/' + dep + '/' + depMain})
+
+
 exports.loadConfig = (configPath = 'brunch-config', options = {}, callback) ->
   try
     # assign fullPath in two steps in case require.resolve throws
@@ -388,6 +406,9 @@ exports.loadConfig = (configPath = 'brunch-config', options = {}, callback) ->
   replaceConfigSlashes config
   normalizeConfig config
   config._normalized.packageInfo = {}
+
+  loadNpm config, (bowerRes) ->
+    console.log bowerRes
 
   loadComponents config, 'bower', (bowerRes)->
     config._normalized.packageInfo.bower = bowerRes

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -13,7 +13,6 @@ commonRequireDefinition = require 'commonjs-require-definition'
 anymatch = require 'anymatch'
 coffee = require 'coffee-script'
 each = require 'async-each'
-deppack = require 'deppack'
 coffee.register()
 
 # Extends the object with properties from another object.

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -116,11 +116,10 @@ startServer = (config, callback = ->) ->
 # Returns nothing.
 initWatcher = (config, callback) ->
   {allConfigFiles} = config._normalized.paths
-  {bower, component} = config._normalized.packageInfo
+  {npm, bower, component} = config._normalized.packageInfo
   getFiles = (pkgs) -> [].concat.apply [], pkgs.components.map (_) -> _.files
-
   watched = config.paths.watched.concat(
-    allConfigFiles, getFiles(bower), getFiles(component)
+    allConfigFiles, getFiles(npm), getFiles(bower), getFiles(component)
   )
 
   exists = (path, callback) ->


### PR DESCRIPTION
This PR is needed to discus some aspects. For now, it is working good with files from npm like 'backbone' or 'react', also, it ignores brunch plugins, but there is some problems when we have packages which require node's native modules like `fs` or `path` (ex. express) . I solved this by adding /^express/ to `conventions.ignored`. My proposition is to create separate branch for this implementation (maybe for collective polishing).