### PR TITLE
There are some cases where `dependent.dependencies` can be undefined

### DIFF
--- a/src/fs_utils/file_list.coffee
+++ b/src/fs_utils/file_list.coffee
@@ -85,6 +85,7 @@ module.exports = class FileList extends EventEmitter
   compileDependencyParents: (path) ->
     parents = @files
       .filter (dependent) =>
+        dependent.dependencies and
         dependent.dependencies.length > 0 and
         path in dependent.dependencies and
         not @compiled[dependent.path]


### PR DESCRIPTION
Hi!

I recently face cases where the `dependent.dependencies` can be undefined (basically, I try to add jQuery to my project through npm).

I don't really know if it's normal or not but in any case, it safer to just check if `dependencies` is not undefined.