### PR TITLE
Handle optional `path` arg

### DIFF
--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -580,5 +580,11 @@ class BrunchWatcher
     start
 
 module.exports = watch = (persistent, path, options, callback = (->)) ->
-  process.chdir path if path
+  # If path isn't provided (by CL)
+  if path
+    if typeof path is 'string'
+      process.chdir path
+    else
+      callback = options if typeof 'options' is 'function'
+      options = path
   new BrunchWatcher(persistent, options, callback)


### PR DESCRIPTION
Hey!

Recently I had an issue with brunch builds failing with versions >= 1.8 (https://github.com/brunch/brunch/issues/967)

The issue was due to the addition of the `path` argument in `watch()`
https://github.com/brunch/brunch/commit/9b9e8c5015856eb8e770f050232e092ee88e822e#diff-5894f29c43782173bc5f20c4d13a4f8d

In my case, it was failing because I had a deployment script that would build on the fly and deploy based on the env (override). This script would call `brunch.build options`, but with the addition of the `path` argument,  path was now being set to my `options` argument. I can get around this by simply adding `brunch.build null, options`. This isn't a difficult fix on my end, but I suspect others might run into the same issue.

This could be cleaned up a bit outside of the watch function, but this PR offers a non-depricating solution to any code currently using the same method as I am for builds.

Feel free to incorporate or improve.

Thanks!