### PR TITLE
Account for absent package dependencies.

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -391,7 +391,7 @@ loadNpm = (config, cb) ->
   catch error
     throw new Error "You probably need to execute `npm install` to install brunch plugins. #{error}"
 
-  items = Object.keys(json.dependencies)
+  items = Object.keys(json.dependencies or {})
     .filter (dep) ->
       # Ignore Brunch plugins.
       dep isnt 'brunch' and


### PR DESCRIPTION
```
/usr/local/lib/node_modules/brunch/lib/helpers.js:532
  items = Object.keys(json.dependencies).filter(function(dep) {
                 ^
TypeError: Object.keys called on non-object
  at Function.keys (native)
  at loadNpm (/usr/local/lib/node_modules/brunch/lib/helpers.js:532:18)
  at addPackageManagers (/usr/local/lib/node_modules/brunch/lib/helpers.js:552:10)
  at Object.exports.loadConfig (/usr/local/lib/node_modules/brunch/lib/helpers.js:595:10)
  at initialize (/usr/local/lib/node_modules/brunch/lib/watch.js:460:18)
  at new BrunchWatcher (/usr/local/lib/node_modules/brunch/lib/watch.js:649:5)
  at module.exports.watch (/usr/local/lib/node_modules/brunch/lib/watch.js:708:10)
  at start (/usr/local/lib/node_modules/brunch/lib/index.js:15:31)
  at Command.listener (/usr/local/lib/node_modules/brunch/node_modules/commander/index.js:289:8)
  at Command.emit (events.js:110:17)
  at Command.parseArgs (/usr/local/lib/node_modules/brunch/node_modules/commander/index.js:572:12)
  at Command.parse (/usr/local/lib/node_modules/brunch/node_modules/commander/index.js:438:21)
  at Object.exports.run (/usr/local/lib/node_modules/brunch/lib/cli.js:63:11)
  at Object.<anonymous> (/usr/local/lib/node_modules/brunch/bin/brunch:11:22)
  at Module._compile (module.js:460:26)
  at Object.Module._extensions..js (module.js:478:10)
  at Module.load (module.js:355:32)
  at Function.Module._load (module.js:310:12)
  at Function.Module.runMain (module.js:501:10)
  at startup (node.js:129:16)
  at node.js:814:3
```