### PR TITLE
Documentation Fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ via modifying config file.
 Brunch also has conventions. Conventions are filters for files with special meaning. They can be changed via config.
 
 * Static files in `assets/` dirs are copied directly to `public/`.
-* Any scripts in `assets/` dirs are wrapped by default into modules. These modules are Common.JS / AMD abstractions that allow you to simply get rid of global vars as to avoid polluting the global namespace. This is especially useful for larger projects. Any module that you need to use in the browser will have to be loaded with the `require('')` function. For example, if you have a script `app/views/user_view`, then you could load that in your html file using `<script>require('views/user_view')</script>`. File extensions are optional here.
+* Any scripts in `app/` dirs are wrapped by default into modules. These modules are Common.JS / AMD abstractions that allow you to simply get rid of global vars as to avoid polluting the global namespace. This is especially useful for larger projects. Any module that you need to use in the browser will have to be loaded with the `require('')` function. For example, if you have a script `app/views/user_view`, then you could load that in your html file using `<script>require('views/user_view')</script>`. File extensions are optional here.
 * Scripts in `vendor/` dirs aren't wrapped in modules and as such do not require any further loading instructions.
 * Files whose name start with `_` (underscore) are ignored by compiler. They're useful for languages like sass / stylus, where you import all substyles in main style file.
 * Files named `-test.<extension>` are considered tests.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,7 +12,7 @@ git / github repo address of project), contents of which will be copied to new d
 
 `.git` directory is automatically removed when copying.
 
-Brunch skeleton is basically an application boilerplate that provides a good starting point for new applications. Creating new application with any skeleton is pretty simple: `brunch new <app> --skeleton <address>`.
+Brunch skeleton is basically an application boilerplate that provides a good starting point for new applications. Creating new application with any skeleton is pretty simple: `brunch new <address> <app>`.
 
 `<address>` can be a:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -72,9 +72,9 @@ files:
 
 `Object`: `conventions` define tests, against which all file pathnames will be checked.
 
-* `ignored` key: [anymatch set](https://github.com/es128/anymatch#anymatch-). Will check against files that should be ignored by brunch compiler, but are still watched by the watcher. For example, when you have `common.styl` file that you import in every stylus file, `common.styl` will be compiled on its own too which will result in duplicated code. When prefixing it with underscore (`_common.styl`) you are still able to import it in dependent files, but it won’t be compiled twice. The feature is very similar to [Sass partials](http://wiseheartdesign.com/articles/2010/01/22/structuring-a-sass-project/). By default, files and directories that start with underscore (`_`) will be ignored, as well as anything under the `vendor/node/` directory.
+* `ignored` key: [anymatch set](https://github.com/es128/anymatch#anymatch-). Will check against files that should be ignored by brunch compiler, but are still watched by the watcher. For example, when you have `common.styl` file that you import in every stylus file, `common.styl` will be compiled on its own too which will result in duplicated code. When prefixing it with underscore (`_common.styl`) you are still able to import it in dependent files, but it won’t be compiled twice. The feature is very similar to [Sass partials](http://wiseheartdesign.com/articles/2010/01/22/structuring-a-sass-project/). By default, files and directories that start with underscore (`_`) will be ignored, as well as anything under the `vendor/node/`, `vendor/ruby-*/`, `vendor/jruby-*/`, and `vendor/bundle/` directories.
 * `assets` key: [anymatch set](https://github.com/es128/anymatch#anymatch-). Default value: `/assets[\\/]/`. If test gives true, file won't be compiled and will be just moved to public directory instead.
-* `vendor` key: [anymatch set](https://github.com/es128/anymatch#anymatch-). Default value: `/vendor[\\/]/`. If test gives true, file won't be wrapped in module, if there are any.
+* `vendor` key: [anymatch set](https://github.com/es128/anymatch#anymatch-). Default value: `/(^bower_components|node_modules|vendor)[\\/]/`. If test gives true, file won't be wrapped in module, if there are any.
 
 Keep in mind that default brunch regexps, as you see, consider **all** `vendor/` (etc.) directories as vendor (etc.) files. So, `app/views/vendor/thing/chaplin_view.coffee` will be treated as vendor file.
 
@@ -234,7 +234,7 @@ server:
 
 ## `sourceMaps`
 
-`Boolean`: enables or disables Source Map generation. Default value is `true` (enabled).
+`Boolean`: enables or disables Source Map generation. Default value is `true` (enabled), `false` (disabled) if you run `brunch build --production`.
 `String`:
   * set to `'old'` to use the old `@` control character instead of `#`.
   * set to `'absoluteUrl'` to set the `sourceMappingURL` to the complete URL path starting from `config.paths.public`

--- a/docs/config.md
+++ b/docs/config.md
@@ -95,7 +95,7 @@ conventions:
 * `commonjs` (Default) — CommonJS wrapper.
 * `amd` — AMD `r.js`-like wrapper.
 * `false` — no wrapping. Files will be compiled as-is.
-* Function that takes path and data
+* Function that takes path, data, and a boolean set to `true` if the file is in a vendor directory. 
 
 `modules.definition`: `String, Boolean or Function` a code that will be added on top of every generated JavaScript file. Values:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -81,7 +81,7 @@ This is useful for explicitly seeing the list of source files that are compiled 
 
 ### Linux/OS X:
 
-Add `DEBUG='brunch:*'` in front of your `brunch` command for on-demand use, such as `DEBUG='brunch:*' brunch build`
+Use the `--debug` (`-d`) option, or add `DEBUG='brunch:*'` in front of your `brunch` command for on-demand use, such as `DEBUG='brunch:*' brunch build`
 
 Or run `export DEBUG='brunch:*'` to persist the setting for the rest of your terminal session.
 Optionally, add this to your `~/.bash_profile`, `~/.zshrc`, etc.


### PR DESCRIPTION
* `docs/config.md`:
    * Updated the default value for `conventions.vendor`: it’s `/(^bower_components|node_modules|vendor)[\\/]/`, but was said to be `/vendor[\\/]/`, which makes it hard to understand how Bower components are handled;

    * Updated the default value for `conventions.ignored `: added `vendor/ruby-*/`, `vendor/jruby-*/`, and `vendor/bundle/`;

    * Added mention of the `isVendor`argument for the `modules.wrapper` function;

* `docs/commands.md`: Corrected an example still using the old `brunch new` syntax with `--skeleton`;

* `docs/faq.md`: Added a mention of the `--debug` option;

* `docs/README.md`: I believe it’s _Any scripts in `app/` dirs_ that are wrapped by default into modules, and not only _Any scripts in `assets/` dirs_, which looks like a copy/paste mistake.