### PR TITLE
Add "overrides" support for NPM.

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -400,6 +400,7 @@ loadNpm = (config, cb) ->
     .map (dep) ->
       depPath = sysPath.join rootPath, 'node_modules', dep
       depJson = require sysPath.join depPath, 'package.json'
+      depJson = deepExtend(depJson, json.overrides[dep]) if json.overrides[dep]
       depMain = depJson.main or 'index.js'
       file = sysPath.join 'node_modules', dep, depMain
       name: dep


### PR DESCRIPTION
Similar to the unofficial `overrides` keyword in `bower.json`, this patch adds support for an unofficial `overrides` keyword in `package.json`, in order to fix issue #986.

A supported `package.json` would be:

    {
      ...

      "dependencies": {
        "react": "*"
      },
      "overrides": {
        "react": {
          "main": "dist/react.js"
        }
      }
    }