### PR TITLE
Support config.modules.autoRequire

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -122,6 +122,15 @@ require.define({#{path}: function(exports, require, module) {
     """
 ```
 
+`modules.autoRequire`: `Object` specifies requires to be automatically added at the end of joined file. The example below will require both 'app' and 'foo':
+
+```coffeescript
+# Default behaviour.
+modules:
+  autoRequire:
+    'javascripts/app.js': ['app', 'foo']
+```
+
 `modules.nameCleaner`: `Function` Allows you to set filterer function for module names,
 for example, change all 'app/file' to 'file'. Example:
 

--- a/src/fs_utils/generate.coffee
+++ b/src/fs_utils/generate.coffee
@@ -61,7 +61,7 @@ sort = (files, config, joinToValue) ->
     indexes[path]
 
 # New.
-concat = (files, path, type, definition, aliases) ->
+concat = (files, path, type, definition, aliases, autoRequire) ->
   # nodes = files.map toNode
   root = new SourceNode()
   debug "Concatenating #{files.map((_) -> _.path).join(', ')} to #{path}"
@@ -75,6 +75,9 @@ concat = (files, path, type, definition, aliases) ->
   aliases?.forEach (alias) ->
     key = Object.keys(alias)[0]
     root.add "require.alias('#{key}', '#{alias[key]}');"
+
+  autoRequire?.forEach (require) ->
+    root.add "require('#{require}');"
 
   root.toStringWithSourceMap file: path
 
@@ -124,7 +127,7 @@ generate = (path, sourceFiles, config, optimizers, callback) ->
   joinToValue = config.files["#{type}s"].joinTo[joinKey]
   sorted = sort sourceFiles, config, joinToValue
 
-  {code, map} = concat sorted, path, type, config._normalized.modules.definition, config._normalized.packageInfo.component.aliases
+  {code, map} = concat sorted, path, type, config._normalized.modules.definition, config._normalized.packageInfo.component.aliases, config._normalized.modules.autoRequire[joinKey]
 
   withMaps = (map and config.sourceMaps)
   mapPath = "#{path}.map"

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -272,6 +272,7 @@ exports.setConfigDefaults = setConfigDefaults = (config, configPath) ->
   modules.wrapper     ?= 'commonjs'
   modules.definition  ?= 'commonjs'
   modules.nameCleaner ?= (path) -> path.replace(/^app\//, '')
+  modules.autoRequire ?= {}
 
   server               = config.server        ?= {}
   server.base         ?= ''
@@ -329,6 +330,7 @@ normalizeConfig = (config) ->
   normalized.modules = {}
   normalized.modules.wrapper = normalizeWrapper mod.wrapper, config.modules.nameCleaner
   normalized.modules.definition = normalizeDefinition mod.definition
+  normalized.modules.autoRequire = mod.autoRequire
   normalized.conventions = {}
   Object.keys(config.conventions).forEach (name) ->
     normalized.conventions[name] = normalizeChecker config.conventions[name]


### PR DESCRIPTION
This allow us to customize which files to automatically
require at the end of each joined file.

Closes #999. Alternative to #1000.