### PR TITLE
Check whether json.overrides is defined

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -402,7 +402,7 @@ loadNpm = (config, cb) ->
     .map (dep) ->
       depPath = sysPath.join rootPath, 'node_modules', dep
       depJson = require sysPath.join depPath, 'package.json'
-      depJson = deepExtend(depJson, json.overrides[dep]) if json.overrides[dep]
+      depJson = deepExtend(depJson, json.overrides[dep]) if json.overrides?[dep]
       depMain = depJson.main or 'index.js'
       file = sysPath.join 'node_modules', dep, depMain
       name: dep


### PR DESCRIPTION
In #987 the overrides support was added. After updating I noticed, that my build failed because `overrides` wasn't defined in my `package.json`. I think this shouldn't be required.

As I'm not using CoffeeScript regularly, I hope this is the correct way to do it.