### PR TITLE
Only listen to stdin if --stdin flag is given

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -35,6 +35,7 @@ watchCmd = program
   .option('-p, --port [port]', 'if a `server` option was specified, define on which port
  the server would run')
   .option('-d, --debug', 'print verbose debug output to stdout')
+  .option('--stdin', 'listen to stdin and exit when stdin closes')
   .action(commands.watch)
 
 addDeprecatedOpts = ->

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -47,6 +47,7 @@ generateParams = (persistent, options) ->
   if options.production? or options.optimize?
     params.env.unshift 'production'
   params.persistent = persistent
+  params.stdin = options.stdin?
   if options.publicPath
     params.paths = {}
     params.paths.public = options.publicPath
@@ -499,7 +500,7 @@ bindWatcherEvents = (config, fileList, compilers, linters, watcher, reload, onCh
     onChange()
     changeFileList compilers, linters, fileList, path, false
 
-  if config.persistent
+  if config.persistent and config.stdin
     process.stdin.on 'end', -> process.exit(0)
     process.stdin.resume()
 


### PR DESCRIPTION
Closes #998

I would really appreciate if there was a release so we can update Phoenix to use the `--stdin` flag from now on.

Also, I did not make the flag hidden, because folks would see it and wonder what it is about. I tried to make it as descriptive as possible though.

Thank you!