### PR TITLE
enable --stdin option

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -35,6 +35,7 @@ watchCmd = program
   .option('-p, --port [port]', 'if a `server` option was specified, define on which port
  the server would run')
   .option('-d, --debug', 'print verbose debug output to stdout')
+  .option('--stdin', 'Read from stdin')
   .action(commands.watch)
 
 addDeprecatedOpts = ->

--- a/src/watch.coffee
+++ b/src/watch.coffee
@@ -54,6 +54,7 @@ generateParams = (persistent, options) ->
     params.server = {}
     params.server.run = true if options.server
     params.server.port = options.port if options.port
+    params.stdin = true if options.stdin
   params
 
 startServer = (config, callback = ->) ->
@@ -499,7 +500,7 @@ bindWatcherEvents = (config, fileList, compilers, linters, watcher, reload, onCh
     onChange()
     changeFileList compilers, linters, fileList, path, false
 
-  if config.persistent
+  if config.persistent and config.stdin
     process.stdin.on 'end', -> process.exit(0)
     process.stdin.resume()
 


### PR DESCRIPTION
If this option is passed, a persistent brunch process will exit if stdin is closed.