### PR TITLE
Add init command

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 const program = require('commander');
 const commands = require('./');
 const aliases = {
+  i: 'init',
   n: 'new',
   b: 'build',
   w: 'watch'
@@ -14,6 +15,10 @@ Object.keys(aliases).forEach(key => {
 });
 
 program.version(require('../package.json').version).usage('[command] [options]');
+
+program.command('init [path]').description('Create new dead simple brunch project in path [.]. Short-cut: i').action(() => {
+  return commands["init"](program.args[0]);
+});
 
 program.command('new [skeleton] [path]').description('Create new brunch project in path [.]. Short-cut: n').action(() => {
   return commands["new"](program.args[0], program.args[1]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,24 @@ const start = (arg0, arg1, arg2) => {
   return fn(arg0, arg1, arg2);
 };
 
+const defaultInitSkeleton = 'https://github.com/brunch/dead-simple';
+
+const getInitSkeleton = () => {
+  if (process.env.BRUNCH_INIT_SKELETON) {
+    return process.env.BRUNCH_INIT_SKELETON;
+  };
+
+  return defaultInitSkeleton;
+};
+
 module.exports = {
+  "init": (path) => {
+    return initSkeleton(getInitSkeleton(), {
+      rootPath: path,
+      commandName: 'brunch init',
+      logger: loggy
+    });
+  },
   "new": (skeleton, path) => {
     return initSkeleton(skeleton, {
       rootPath: path,


### PR DESCRIPTION
Add a new `init` command to quickly create new projects with a default skeleton (defined in the ENV, or 'dead-simple' otherwise).

```sh
brunch init ./fun-project
```

```sh
BRUNCH_INIT_SKELETON=dead-simpler brunch init ./funner-project
```

Towards #1024