### PR TITLE
We have to return the 'write' promise, else the callbacks are called …

### DIFF
--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -192,12 +192,15 @@ const generate = (path, sourceFiles, config, optimizers) => {
       return Promise.reject(error);
     })
     .then(data => {
-      common.writeFile(path, data.code);
-      return data;
+      return common.writeFile(path, data.code).then(() => {
+        return data;
+      });
     })
     .then(data => {
       if (withMaps) {
-        common.writeFile(mapPath, data.map.toString());
+        return common.writeFile(mapPath, data.map.toString()).then(() => {
+          return data;
+        });
       }
       return data;
     });


### PR DESCRIPTION
…before the files are actually written