### PR TITLE
Reset cursor when process is exited

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -205,9 +205,9 @@ const load = (config, json, deps) => new Promise((resolve, reject) => {
 
   const resolveItems = (items, cb) => {
     each(items, readItem, (err, redItems) => {
-      const wDeps = redItems.map(detect);
-
       if (err) return cb(err);
+
+      const wDeps = redItems.map(detect);
 
       each(wDeps, resolveDeps, (err, resolvedItems) => {
         if (err) return cb(err);

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,26 +1,28 @@
 const charm = require('charm')(process);
 const logger = require('loggy');
 
+process.on('exit', () => charm.cursor(true));
+
 const animatedProgress = (level, base) => {
   var num = 0;
   const nextNum = () => [1, 2, 3, 0][num];
   const infoOffset = logger.entryFormat.length + 3 + level.length;
 
   const writeWithDots = () => {
-    charm.cursor(false);
     charm.left(1000);
     charm.right(infoOffset);
     charm.erase('end');
-    const line = base + ['   ', '.  ', '.. ', '...'][num];
+    const line = base + '...'.slice(0, num);
     num = nextNum();
     process.stdout.write(line);
   };
 
-  logger[level](base + '   ');
+  logger[level](base);
 
+  charm.cursor(false);
   charm.up(1);
   charm.right(infoOffset);
-  const inv = setInterval(writeWithDots, 500);
+  const inv = setInterval(writeWithDots, 250);
 
   return () => {
     clearInterval(inv);


### PR DESCRIPTION
Currently if one Ctrl+C's during the "compiling..." animation, the cursor in the shell will still be disabled. This aims to fix that.