### PR TITLE
Allow to create aliases for deppack modules

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -284,6 +284,14 @@ const processFiles = (config, root, files, processor) => {
     return `${shim}: (${safe})`;
   });
 
+  const aliases = Object.keys(config.npm.aliases || []).map(target => {
+    const source = config.npm.aliases[target];
+
+    return `require.register("${target}", function(exports, require, module) {
+      module.exports = require("${source}");
+    });`
+  });
+
   const items = JSON.stringify(Object.keys(shims));
   root.add(`(function() {
     var global = window;
@@ -299,6 +307,7 @@ const processFiles = (config, root, files, processor) => {
     };
   `);
   files.forEach(processor);
+  root.add(aliases.join());
   root.add('})();');
 
   insertGlobals(config, root);


### PR DESCRIPTION
This is going to be useful to, for example, allow registering `exoskeleton` as `backbone` and make chaplin ok with it