### PR TITLE
Small fix to watching for some editors

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -336,6 +336,7 @@ const normalizeConfig = config => {
   normalized.packageInfo = {};
   normalized.persistent = config.persistent;
   normalized.usePolling = !!(config.watcher && config.watcher.usePolling);
+  normalized.awaitWriteFinish = !!(config.watcher && config.watcher.awaitWriteFinish);
   config._normalized = normalized;
   ['on', 'off', 'only'].forEach(key => {
     if (typeof config.plugins[key] === 'string') {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -139,6 +139,8 @@ class BrunchWatcher {
     const config = this.config._normalized;
     const persistent = config.persistent;
     const usePolling = config.usePolling;
+    const awaitWriteFinish = config.awaitWriteFinish &&
+      {stabilityThreshold: 50, pollInterval: 10};
     const possibleConfigFiles = config.paths.possibleConfigFiles;
     const rootPath = config.paths.root;
     const packageConfig = config.paths.packageConfig;
@@ -148,7 +150,8 @@ class BrunchWatcher {
 
     profileBrunch('Loaded watcher');
     return chokidar.watch(watchedPaths, {
-      ignored: fsUtils.ignored, persistent: persistent, usePolling: usePolling
+      ignored: fsUtils.ignored, persistent: persistent, usePolling: usePolling,
+      awaitWriteFinish: awaitWriteFinish
     })
       .on('error', logger.error)
       .on('add', absPath => {


### PR DESCRIPTION
Some editors, such as Emacs, make backups while saving. This causes
files to be momentarily empty before the new contents are written. This
then results in a race between Brunch and the editor, trying to compile
the file and write the file at the same time. See also issue #971.

As a workaround, it's possible to delay the watch. This adds a new
watcher config option `fixEditorSave`. When true, the watcher will wait
up to 50ms for the write to stabilize.