### PR TITLE
Properly split path on Windows

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -35,13 +35,13 @@ const readFile = (path, callback) => {
 };
 
 const getModuleRootPath = path => {
-  const split = path.split('/');
+  const split = path.split(sysPath.sep);
   const index = split.lastIndexOf('node_modules');
-  return split.slice(0, index + 2).join('/');
+  return split.slice(0, index + 2).join(sysPath.sep);
 };
 
 const getModuleRootName = path => {
-  const split = path.split('/');
+  const split = path.split(sysPath.sep);
   const index = split.lastIndexOf('node_modules');
   return split[index + 1];
 };


### PR DESCRIPTION
See report here: https://github.com/phoenixframework/phoenix/issues/1463#issuecomment-170171217

Once the user reports it works on Windows, a 2.1.3 release
would be appreciated. I will drop a note here. :)