### PR TITLE
Use module's root path as relative path.

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -46,7 +46,6 @@ const getModuleRootName = path => {
   return split[index + 1];
 };
 
-const getModuleMainPath = path => sysPath.dirname(getMainFile(path));
 const relativeToRoot = (filePath, relPath) => sysPath.join(
   getModuleRootPath(filePath), relPath
 );
@@ -103,7 +102,7 @@ const generateModule = (filePath, source) => {
 };
 
 const generateModuleName = filePath => {
-  const rp = getModuleMainPath(filePath);
+  const rp = getModuleRootPath(filePath);
   const mn = getModuleRootName(filePath) +
     (isMain(filePath) ? '' : filePath.replace(rp, '').replace('.js', ''));
 


### PR DESCRIPTION
I am trying to play with React + Omniscient using brunch.io 2.1.3. My minimal package.json looks like

```
{
  "repository": {},
  "dependencies": {
    "babel-brunch": "^6.0.0",
    "brunch": "^2.1.1",
    "clean-css-brunch": ">= 1.0 < 1.8",
    "css-brunch": ">= 1.0 < 1.8",
    "immstruct": "^2.0.0",
    "immutable": "^3.7.6",
    "javascript-brunch": ">= 1.0 < 1.8",
    "moment": "^2.11.0",
    "omniscient": "^4.1.1",
    "react": "^0.14.5",
    "react-dom": "^0.14.5",
    "sass-brunch": "^1.9.2",
    "transducers-js": "^0.4.174",
    "uglify-js-brunch": ">= 1.0 < 1.8"
  },
  "devDependencies": {
    "babel-preset-react": "^6.3.13"
  }
}
```

My brunch setup uses NPM to load modules. Here is the relevant section:

```
npm: {
  enabled: true,
  whitelist: [
    'immutable',
    'omniscient',
    'immstruct',
    'react',
    'react-dom',
    'transducers-js'
  ]
}
```

Omniscient is relying on [immutable.js](https://github.com/facebook/immutable-js) and particularly it's cursor contrib library. The layout of the relevant parts is 

```
immutable
  contrib
    cursor
      index.js
  dist
    immutable.js <-- main file
```

When brunch is trying to load immutable.js, it properly packs `immutable` module. However, the cursor library is imported with the name 

`immutable/Users/saaji/proj/omni-test/node_modules/immutable/contrib/cursor/index`. 

while Immutable.js/Omniscient are expecting module named `immutable/contrib/cursor`.

This is due to the fact that in brunch module's relative path is being calculated up to main file. In case of immutable.js up to `node_modules/immutable/dist` instead of just `node_modules/immutable`. 

Setting module's relative path equal to module's root path fixes this issue. Cursor library it being loaded as it should, `immutable/contrib/cursor`. Brunch tests are passing too. Other libraries are also being loaded correctly.
