### PR TITLE
Normalize deppack's module name against Windows backslash path

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -101,12 +101,14 @@ const generateModule = (filePath, source) => {
   return getNewHeader(mn, source, expandedPath);
 };
 
+const slashes = string => string.replace(/\\/g, '/');
+
 const generateModuleName = filePath => {
   const rp = getModuleRootPath(filePath);
   const mn = getModuleRootName(filePath) +
     (isMain(filePath) ? '' : filePath.replace(rp, '').replace('.js', ''));
 
-  return mn;
+  return slashes(mn);
 };
 
 const isDir = fileOrDir => {


### PR DESCRIPTION
This pull request fixes similar problem reported on #1035 and fixed on 37b3901 .

Currently `deppack.js` wrongly generates module name contain backslashes when `bundle build` is executed on Windows because of their backslash path separator. It should be normalized to front slashes to work properly, because when the module required, its name assumed to be separated with front slashes.

I found this issue when I tried to follow the post on my Windows development environment.
https://medium.com/@diamondgfx/phoenix-v1-1-2-and-react-js-3dbd195a880a