### PR TITLE
Fix browser mapping with false values

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -69,7 +69,7 @@ const expandedFilePath = filePath => {
 
   Object.keys(brMap).filter(isRelative).forEach(key => {
     const val = brMap[key];
-    if (filePath === relativeToRoot(filePath, val)) {
+    if (val && filePath === relativeToRoot(filePath, val)) {
       filePath = relativeToRoot(filePath, key);
     }
   });


### PR DESCRIPTION
Fix a compilation issue with:
```
"browser": {
    "./lib/locales": false,
    "./lib/locales.js": false
  },
```
https://github.com/brunch/brunch/issues/1108