### PR TITLE
Update browser-resolve dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "read-components": "~0.6.0",
     "source-map": "~0.5.0",
     "async-each": "~0.1.6",
-    "browser-resolve": "~1.7.2",
+    "browser-resolve": "~1.11.1",
     "detective": "~4.0.0",
     "glob": "~6.0.0"
   },


### PR DESCRIPTION
The underlying `resolve` library has a bug in versions <1.1.7 which means it doesn't work on Windows when using relative paths (like `.`). This breaks the `npm.globals` config on Windows. I can confirm that updating this dependency does fix it.