### PR TITLE
Override npm packages attributes fixes

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -160,7 +160,7 @@ let paths;
 let nameCleaner;
 
 const getDepPackageJson = depPath => {
-  let depJson = require(sysPath.join(depPath, 'package.json'));
+  const depJson = require(sysPath.join(depPath, 'package.json'));
   applyPackageOverrides(depJson);
   return depJson;
 };
@@ -170,7 +170,7 @@ const globalPseudofile = '___globals___';
 const resolveErrorRe = /Cannot find module '(.+)' from '(.+)'/;
 
 const applyPackageOverrides = (pkg) => {
-  let pkgOverride = overrides[pkg.name];
+  const pkgOverride = overrides[pkg.name];
 
   if (pkgOverride) {
     pkg = deepExtend(pkg, pkgOverride);

--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -160,17 +160,25 @@ let paths;
 let nameCleaner;
 
 const getDepPackageJson = depPath => {
-  const dep = getModuleRootName(depPath);
   let depJson = require(sysPath.join(depPath, 'package.json'));
-  if (overrides[dep]) {
-    depJson = deepExtend(depJson, overrides[dep]);
-  }
+  applyPackageOverrides(depJson);
   return depJson;
 };
 
 const globalPseudofile = '___globals___';
 
 const resolveErrorRe = /Cannot find module '(.+)' from '(.+)'/;
+
+const applyPackageOverrides = (pkg) => {
+  let pkgOverride = overrides[pkg.name];
+
+  if (pkgOverride) {
+    pkg = deepExtend(pkg, pkgOverride);
+  }
+
+  return pkg;
+};
+
 const xBrowserResolve = (mod, opts, cb) => {
   browserResolve(mod, opts, (err, res) => {
     if (err) {
@@ -183,9 +191,13 @@ const xBrowserResolve = (mod, opts, cb) => {
         err = isGlob ? `Could not load global module '${mod}'.` : `Could not load module '${mod}' from '${src}'.`;
 
         if (packages[topLevel] == null) {
-          err = err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
+          err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
         } else {
-          err = err += ` Possible solution: run \`npm install\`.`;
+          if (overrides[mod]) {
+            err += ` Possible solution: check your overrides in package.json.`;
+          } else {
+            err += ` Possible solution: run \`npm install\`.`;
+          }
         }
       }
       err = new Error(err);
@@ -209,7 +221,7 @@ const loadInit = (config, json) => new Promise((resolve, reject) => {
   const globals = config.npm.globals || {};
   const styles = config.npm.styles || {};
 
-  const res = (i, cb) => xBrowserResolve(i, {filename: globalPseudofile}, cb);
+  const res = (i, cb) => xBrowserResolve(i, {filename: globalPseudofile, packageFilter: applyPackageOverrides}, cb);
 
   const globModules = Object.keys(globals).map(k => globals[k]);
   each(globModules, res, (err, fullPaths) => {
@@ -352,7 +364,7 @@ const exploreDeps = fileList => {
     const allDeps = isVendor(path) ? [] : detective(x.compiled);
     const deps = isApp(path) ? allDeps.filter(x => !isRelative(x)) : allDeps;
 
-    const res = (i, cb) => xBrowserResolve(i, {filename: path, modules: modMap}, cb);
+    const res = (i, cb) => xBrowserResolve(i, {filename: path, modules: modMap, packageFilter: applyPackageOverrides}, cb);
 
     return buildModMap().then(() => {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Hello there.

After updating to 2.2 *(2.1.3 fine)* I've found that overrides section from my package.json not working anymore.

Overriding package.json is implemented in `./lib/deppack.js`.

I found that `browserResolve` doesn't care about overrides in my local `./package.json` because it is trying to read original package.json of module (`./node_modules/cool-package/package.json`).

