### PR TITLE
Deppack shims

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -196,9 +196,9 @@ const xBrowserResolve = (mod, opts, cb) => {
           err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
         } else {
           if (overrides[mod]) {
-            err += ` Possible solution: check your overrides in package.json.`;
+            err += " Possible solution: run `npm install` and check your overrides in package.json.";
           } else {
-            err += ` Possible solution: run \`npm install\`.`;
+            err += " Possible solution: run `npm install`.";
           }
         }
       }

--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -9,21 +9,52 @@ const mediator = require('./mediator');
 const glob = require('glob');
 const promisify = require('./helpers').promisify;
 
-const specialShims = { process: { env: { NODE_ENV: process.env.NODE_ENV } } };
-const emptyShims = [
-  'assert', 'buffer', 'child_process', 'cluster', 'crypto', 'dgram', 'dns',
-  'domain', 'events', 'fs', 'http', 'https', 'net', 'os', 'path', 'punycode',
-  'querystring', 'readline', 'repl', 'string_decoder', 'tls', 'tty', 'url',
-  'util', 'vm', 'zlib'
-];
-const shims = Object.assign(emptyShims.reduce((memo, el) => {
+const nodeMods = require('node-browser-modules');
+
+const emptyShims = nodeMods.emptyShims;
+const fileShims = nodeMods.fileShims;
+
+const fileShimPaths = Object.keys(fileShims).map(x => fileShims[x]);
+
+const dir = sysPath.dirname(sysPath.dirname(require.resolve('.')));
+
+exports.isNpm = path => {
+  if (!mediator.npmIsEnabled) return false;
+  return path.indexOf('node_modules') >= 0 &&
+    !brunchRe.test(path) && path.indexOf('.css') === -1 ||
+    path.indexOf(sysPath.dirname(sysPath.dirname(require.resolve('..')))) === 0;
+
+  /* Brunch modules. */
+};
+
+exports.isShim = path => path.indexOf(dir) === 0;
+const shims = emptyShims.reduce((memo, el) => {
   memo[el] = {};
   return memo;
-}, {}), specialShims);
+}, {});
 
 const specialShimFile = '___shims___';
 
+const isSimpleShim = x => x.indexOf(specialShimFile) === 0;
+const isFileShim = x => fileShimPaths.indexOf(x) !== -1;
+const isActualShim = x => isSimpleShim(x) || isFileShim(x);
+
+const actualShimName = x => {
+  if (x.indexOf(specialShimFile) === 0) {
+    return x.slice(specialShimFile.length + 1);
+  } else {
+    return Object.keys(fileShims).find(y => fileShims[y] === x);
+  }
+};
+
 const not = f => i => !f(i);
+
+const uniq = list => {
+  return Object.keys(list.reduce((obj, _) => {
+    if (!obj[_]) obj[_] = true;
+    return obj;
+  }, {}));
+};
 
 const readFile = (path, callback) => fs.readFile(path, {encoding: 'utf8'}, callback);
 
@@ -77,6 +108,18 @@ const expandedFilePath = filePath => {
   return filePath;
 };
 
+const aliasDef = (target, source) => {
+  return `require.register('${target}', function(exports,require,module) {
+    module.exports = require('${source}');
+  });`;
+};
+
+const simpleShimDef = (name, obj) => {
+  return `require.register('${name}', function(exports, require, module) {
+    module.exports = ${JSON.stringify(obj)};
+  });`;
+};
+
 const isMain = filePath => getMainFile(filePath) === filePath;
 
 const getNewHeader = (moduleName, source, filePath) => {
@@ -88,12 +131,22 @@ const getNewHeader = (moduleName, source, filePath) => {
     "function(n) { return req(n.replace('./', '" + p2 + "/')); }" :
     'req';
 
+  // core-util-is, used by the stream shims, relies on the Buffer global
+  const includeBuffer = moduleName === 'core-util-is';
+  const glob = includeBuffer ? `var Buffer = require('buffer');\n` : '';
+
+  if (moduleName === 'stream-browserify') moduleName = 'stream';
+
+  const fbModuleName = generateFileBasedModuleName(filePath);
+  const includeFbAlias = isMain(filePath);
+  const fbAlias = aliasDef(fbModuleName, moduleName);
+
   return `require.register('${moduleName}', function(exports,req,module){
     var require = __makeRequire((${r}), ${JSON.stringify(brMap)});
     (function(exports,require,module) {
-      ${source}
+      ${glob}${source}
     })(exports,require,module);
-  });`;
+  });${includeFbAlias ? fbAlias : ''}`;
 };
 
 const generateModule = (filePath, source) => {
@@ -111,6 +164,10 @@ const generateModuleName = filePath => {
     (isMain(filePath) ? '' : filePath.replace(rp, '').replace('.js', ''));
 
   return slashes(mn);
+};
+
+const generateFileBasedModuleName = filePath => {
+  return slashes(getModuleRootName(filePath) + filePath.replace(getModuleRootPath(filePath), '').replace('.js', ''));
 };
 
 const isDir = fileOrDir => {
@@ -161,16 +218,6 @@ let conventions = {};
 let paths;
 let nameCleaner;
 
-const getDepPackageJson = depPath => {
-  const depJson = require(sysPath.join(depPath, 'package.json'));
-  applyPackageOverrides(depJson);
-  return depJson;
-};
-
-const globalPseudofile = '___globals___';
-
-const resolveErrorRe = /Cannot find module '(.+)' from '(.+)'/;
-
 const applyPackageOverrides = (pkg) => {
   const pkgOverride = overrides[pkg.name];
 
@@ -180,6 +227,23 @@ const applyPackageOverrides = (pkg) => {
 
   return pkg;
 };
+const getDepPackageJson = depPath => {
+  const depJson = require(sysPath.join(depPath, 'package.json'));
+  applyPackageOverrides(depJson);
+  return depJson;
+};
+
+const aliasedFileShims = Object.keys(fileShims).reduce((acc, shim) => {
+  const actualMod = generateModuleName(fileShims[shim]);
+  if (shim !== actualMod) {
+    acc[shim] = actualMod;
+  }
+  return acc;
+}, {});
+
+const globalPseudofile = '___globals___';
+
+const resolveErrorRe = /Cannot find module '(.+)' from '(.+)'/;
 
 const xBrowserResolve = (mod, opts, cb) => {
   browserResolve(mod, opts, (err, res) => {
@@ -196,9 +260,9 @@ const xBrowserResolve = (mod, opts, cb) => {
           err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
         } else {
           if (overrides[mod]) {
-            err += " Possible solution: run `npm install` and check your overrides in package.json.";
+            err += ' Possible solution: run `npm install` and check your overrides in package.json.';
           } else {
-            err += " Possible solution: run `npm install`.";
+            err += ' Possible solution: run `npm install`.';
           }
         }
       }
@@ -225,34 +289,36 @@ const loadInit = (config, json) => new Promise((resolve, reject) => {
 
   const res = (i, cb) => xBrowserResolve(i, {filename: globalPseudofile, packageFilter: applyPackageOverrides}, cb);
 
-  const globModules = Object.keys(globals).map(k => globals[k]);
-  each(globModules, res, (err, fullPaths) => {
-    if (err) return reject(err);
+  buildModMap().then(() => {
+    const globModules = Object.keys(globals).map(k => globals[k]);
+    each(globModules, res, (err, fullPaths) => {
+      if (err) return reject(err);
 
-    addFileMods(globalPseudofile, globModules);
-    addFileFiles(globalPseudofile, fullPaths.map(makeRelative));
+      addFileMods(globalPseudofile, globModules);
+      addFileFiles(globalPseudofile, fullPaths.map(makeRelative));
 
-    const styleComps = Object.keys(styles).map(pkg => {
-      const stylesheets = styles[pkg];
-      const root = sysPath.join(rootPath, 'node_modules', pkg);
+      const styleComps = Object.keys(styles).map(pkg => {
+        const stylesheets = styles[pkg];
+        const root = sysPath.join(rootPath, 'node_modules', pkg);
 
-      return {
-        component: pkg,
-        files: stylesheets.map(style => sysPath.join(root, style))
-      };
+        return {
+          component: pkg,
+          files: stylesheets.map(style => sysPath.join(root, style))
+        };
+      });
+
+      const globComps = [{
+        component: globalPseudofile,
+        files: fullPaths.map(makeRelative)
+      }];
+
+      resolve({ components: styleComps.concat(globComps) });
     });
-
-    const globComps = [{
-      component: globalPseudofile,
-      files: fullPaths.map(makeRelative)
-    }];
-
-    resolve({ components: styleComps.concat(globComps) });
   });
 });
 
 const insertGlobals = (config, root) => {
-  const globals = config.npm.globals || {};
+  const globals = Object.assign({}, config.npm.globals || {});
 
   Object.keys(globals).forEach(glob => {
     root.add(`window.${glob} = require('${globals[glob]}');`);
@@ -261,39 +327,44 @@ const insertGlobals = (config, root) => {
 
 const needsProcessing = file => file.path.indexOf('node_modules') !== -1 &&
   file.path.indexOf('.js') !== -1 &&
-  !brunchRe.test(file.path);
+  !brunchRe.test(file.path) ||
+  exports.isNpm(file.path);
 
 const processFiles = (config, root, files, processor) => {
-  const shimSts = Object.keys(shims).map(shim => {
-    const val = shims[shim];
-    const safe = typeof val === 'string' ? val : JSON.stringify(val);
-    return `${shim}: (${safe})`;
+  const shimAliases = usedShims.reduce((acc, x) => {
+    if (aliasedFileShims[x]) {
+      acc[x] = aliasedFileShims[x];
+    }
+    return acc;
+  }, {});
+
+  const _aliases = Object.assign({}, config.npm.aliases || {}, shimAliases, {'process/browser': 'process'});
+
+  const aliases = Object.keys(_aliases).map(target => {
+    if (target === 'stream') return '';
+    return aliasDef(target, _aliases[target]);
   });
 
-  const aliases = Object.keys(config.npm.aliases || []).map(target => {
-    const source = config.npm.aliases[target];
-
-    return `require.register("${target}", function(exports, require, module) {
-      module.exports = require("${source}");
-    });`;
+  const shimDefs = usedShims.filter(x => shims[x]).map(shim => {
+    return simpleShimDef(shim, shims[shim]);
   });
 
-  const items = JSON.stringify(Object.keys(shims));
   root.add(`(function() {
     var global = window;
-    var __shims = {${shimSts.join(',')}};
-    var process = __shims.process;
+    ${shimDefs.join('\n')}
+    var process;
 
     var __makeRequire = function(r, __brmap) {
       return function(name) {
         if (__brmap[name] !== undefined) name = __brmap[name];
         name = name.replace(".js", "");
-        return ${items}.indexOf(name) === -1 ? r(name) : __shims[name];
+        return r(name);
       }
     };
   `);
   files.forEach(processor);
-  root.add(aliases.join());
+  root.add(aliases.join('\n'));
+  root.add("process = require('process');");
   root.add('})();');
 
   insertGlobals(config, root);
@@ -301,9 +372,12 @@ const processFiles = (config, root, files, processor) => {
 
 const fileModMap = {};
 const fileFileMap = {};
+let usedShims = [];
 
 const addFileMods = (file, mods) => fileModMap[file] = mods;
 const addFileFiles = (file, files) => fileFileMap[file] = files;
+
+const addShims = shims => usedShims = uniq(usedShims.concat(shims));
 
 const removeFileMods = file => delete fileModMap[file];
 
@@ -340,11 +414,16 @@ const buildModMap = () => {
     }, {});
 
     const shimModMap = Object.keys(shims).filter(x => packages[x] == null).reduce((acc, shim) => {
-      acc[shim] = specialShimFile;
+      acc[shim] = specialShimFile + '/' + shim;
       return acc;
     }, {});
 
-    modMap = Object.assign({}, modMap0, shimModMap);
+    const shimFileMap = Object.keys(fileShims).filter(x => packages[x] == null).reduce((acc, shim) => {
+      acc[shim] = fileShims[shim];
+      return acc;
+    }, {});
+
+    modMap = Object.assign({}, modMap0, shimModMap, shimFileMap);
   });
 };
 
@@ -368,33 +447,41 @@ const exploreDeps = fileList => {
 
     const res = (i, cb) => xBrowserResolve(i, {filename: path, modules: modMap, packageFilter: applyPackageOverrides}, cb);
 
-    return buildModMap().then(() => {
-      return new Promise((resolve, reject) => {
-        if (fileModsNotChanged(path, deps)) return resolve(x);
+    return new Promise((resolve, reject) => {
+      if (fileModsNotChanged(path, deps)) return resolve(x);
 
-        addFileMods(path, deps);
+      addFileMods(path, deps);
 
-        each(deps, res, (err, fullPaths) => {
-          if (err) {
-            removeFileMods(path);
-            return reject(err);
+      each(deps, res, (err, fullPaths) => {
+        if (err) {
+          removeFileMods(path);
+          return reject(err);
+        }
+
+        const relPaths = fullPaths.filter(not(isSimpleShim)).map(makeRelative);
+        const shims = fullPaths.filter(isActualShim).map(actualShimName);
+
+        if (deps.indexOf('util') !== -1) relPaths.push(fileShims.util);
+
+        //const origPaths = getFileFiles(path);
+        addFileFiles(path, relPaths);
+        if (usedShims.length === 0) {
+          fileList.watcher.changeFileList(fileShims.process, false);
+        }
+        if (shims.length) {
+          addShims(shims);
+        }
+        // dynamically add dependent package files to the watcher list
+        // deppack should also remove npm package files from the watcher list if the dep is no longer being required
+        // the above above does not work for some reason ([TypeError: Cannot assign to read only property 'path' of #<SourceFile>])
+        //const removedFiles = getRemovedFiles(origPaths, fullPaths);
+        //removedFiles.forEach(p => fileList.emit('unlink', p));
+        relPaths.forEach(p => {
+          if (!fileList.find(p)) {
+            fileList.watcher.changeFileList(p, false);
           }
-
-          const relPaths = fullPaths.filter(x => x !== specialShimFile).map(makeRelative);
-          //const origPaths = getFileFiles(path);
-          addFileFiles(path, relPaths);
-          // dynamically add dependent package files to the watcher list
-          // deppack should also remove npm package files from the watcher list if the dep is no longer being required
-          // the above above does not work for some reason ([TypeError: Cannot assign to read only property 'path' of #<SourceFile>])
-          //const removedFiles = getRemovedFiles(origPaths, fullPaths);
-          //removedFiles.forEach(p => fileList.emit('unlink', p));
-          relPaths.forEach(p => {
-            if (!fileList.find(p)) {
-              fileList.watcher.changeFileList(p, false);
-            }
-          });
-          resolve(x);
         });
+        resolve(x);
       });
     });
   };

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -6,6 +6,7 @@ const fcache = require('fcache');
 const Asset = require('./asset');
 const SourceFile = require('./source_file');
 const formatError = require('../helpers').formatError;
+const deppack = require('../deppack');
 
 const startsWith = (string, substring) => {
   return string.lastIndexOf(substring, 0) === 0;
@@ -58,6 +59,7 @@ class FileList {
   }
 
   isIgnored(path, test) {
+    if (deppack.isNpm(path)) return false;
     if (test == null) test = this.conventions.ignored;
     if (this.configPaths.indexOf(path) >= 0) return true;
     switch (toString.call(test).slice(8, -1)) {

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -5,7 +5,6 @@ const helpers = require('../helpers');
 const promisify = helpers.promisify;
 const cachedRead = promisify(require('fcache').readFile);
 const deppack = require('../deppack');
-const mediator = require('../mediator');
 const promisifyPlugin = helpers.promisifyPlugin;
 
 // Pipeline: File -> File.
@@ -146,16 +145,6 @@ const compile = (source, path, compilers) => {
     });
 };
 
-const brre = /brunch/;
-
-const isNpm = path => {
-  if (!mediator.npmIsEnabled) return false;
-  return path.indexOf('node_modules') >= 0 &&
-    !brre.test(path) && path.indexOf('.css') === -1;
-
-  /* Brunch modules. */
-};
-
 const depOptions = {
   basedir: '.',
   rollback: false,
@@ -165,7 +154,7 @@ const depOptions = {
 const warningRe = /^warn\:\s/i;
 
 exports.pipeline = (path, linters, compilers, fileList) => {
-  if (isNpm(path)) {
+  if (deppack.isNpm(path)) {
     return deppack.wrapInModule(path, depOptions)
       .then(source => {
         return {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "async-each": "~0.1.6",
     "browser-resolve": "~1.11.1",
     "detective": "~4.0.0",
-    "glob": "~6.0.0"
+    "glob": "~6.0.0",
+    "node-browser-modules": "github:brunch/node-browser-modules"
   },
   "devDependencies": {
     "chai": "~3.4.1",


### PR DESCRIPTION
This PR is missing a shim for `zlib`, because some of its deps relies on `require`ing json files and brunch/deppack don't currently handle that. Since `zlib` is probably the least used shim, it might be ok to leave it out for now.

Not sure, but could it make sense create a separate package just to depend on shim packages? Otherwise brunch's packages.json is going to be cluttered with that, and the purpose is not exactly obvious. I grouped these in a separate "section" in packages for now...

The PR still needs some cleaning up and rebasing, so don't merge just yet :)