### PR TITLE
Change ver to version, fix #1132

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -6,7 +6,7 @@ global.brunchStartTime = Date.now();
 var sysPath = require('path');
 var fs = require('fs');
 var version = process.version;
-var verDigit = parseInt(ver.match(/^v(\d+)\./)[1]);
+var verDigit = parseInt(version.match(/^v(\d+)\./)[1]);
 
 if (verDigit < 4) {
   return console.error(


### PR DESCRIPTION
`ver` is changed to `version`, fixes #1132 