### PR TITLE
Make process shim path relative

### DIFF
--- a/lib/deppack.js
+++ b/lib/deppack.js
@@ -477,7 +477,7 @@ const exploreDeps = fileList => {
         //const origPaths = getFileFiles(path);
         addFileFiles(path, relPaths);
         if (usedShims.length === 0) {
-          fileList.watcher.changeFileList(fileShims.process, false);
+          fileList.watcher.changeFileList(makeRelative(fileShims.process), false);
         }
         if (shims.length) {
           addShims(shims);


### PR DESCRIPTION
This fixes #1141. Just need to make sure the shim path is made relative.