### PR TITLE
Fixed crash when compiling assets that don't generate JS source

### DIFF
--- a/lib/deppack/explore.js
+++ b/lib/deppack/explore.js
@@ -65,6 +65,7 @@ const isApp = path => !mediator.conventions.vendor.test(path);
 
 const exploreDeps = fileList => {
   return x => {
+    if (!x) return;
     const path = x.path;
 
     if (!isJs(fileList, path) || !mediator.npmIsEnabled) return Promise.resolve(x);


### PR DESCRIPTION
Before [this commit](https://github.com/brunch/brunch/commit/0c1dec1dddff18664de40a52302d2d4814be6be9#diff-6f4bba58e4958ed5756cabd5f320a564), Brunch supported passing null as the second argument to a plugin's compile callback to generate no source code. The above commit broke this behaviour and throws an exception. This broke the jaded-brunch plugin. This change restores the old behaviour.