### PR TITLE
Make preCompile work

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -179,22 +179,35 @@ exports.init = (config, onCompile) => {
   /* Get plugin preCompile callbacks. */
   const preCompilers = plugins.filter(propIsFunction('preCompile'))
   .map(plugin => {
-    // => don't support arguments.
-    return function() {
-      let i = 2 <= arguments.length ? arguments.length - 1 : 0;
-      const cb = arguments[i++];
-      return plugin.preCompile(cb);
-    };
+    return new Promise((resolve, reject) => {
+      if (plugin.preCompile.length === 1) {
+        plugin.preCompile(resolve);
+      } else {
+        const ret = plugin.preCompile();
+        if (ret && ret.then) {
+          ret.then(resolve, reject);
+        } else {
+          resolve();
+        }
+      }
+    });
   });
 
   /* Add preCompile callback from config. */
   if (typeof config.preCompile === 'function') {
     // => don't support arguments.
-    preCompilers.push(function() {
-      let i = 2 <= arguments.length ? arguments.length - 1 : 0;
-      const cb = arguments[i++];
-      return config.preCompile(cb);
-    });
+    preCompilers.push(new Promise((resolve, reject) => {
+      if (config.preCompile.length === 1) {
+        config.preCompile(resolve);
+      } else {
+        const ret = config.preCompile();
+        if (ret && ret.then) {
+          ret.then(resolve, reject);
+        } else {
+          resolve();
+        }
+      }
+    }));
   }
 
   /* Get plugin onCompile callbacks. */


### PR DESCRIPTION
Since the `preCompilers` array is passed to `Promise.all` in the watcher, the array has to be of promises. 

Currently it contains functions so no pre-compiler gets fired. This PR addresses that by:

* making `preCompilers` an array of promises
* allowing individual `preCompile` to accept one argument, a callback
* **or,** allowing individual `preCompile` to accept no arguments and return a promise
* **or,** allowing individual `preCompile` to accept no arguments and return nothing

#1082 