### PR TITLE
Handle nested dependencies

### DIFF
--- a/lib/deppack/modules.js
+++ b/lib/deppack/modules.js
@@ -20,6 +20,14 @@ const getModuleRootName = path => {
   return split[index + 1];
 };
 
+const getModuleFullRootName = path => {
+  const split = path.split(sysPath.sep);
+  const indexS = split.indexOf('node_modules');
+  const indexE = split.lastIndexOf('node_modules');
+  return split.slice(indexS + 1, indexE + 2).join('/');
+};
+
+
 const aliasDef = (target, source) => {
   return `require.register('${target}', function(exports,require,module) {
     module.exports = require('${source}');
@@ -133,7 +141,7 @@ const getNewHeader = (moduleName, source, filePath) => {
     '';
 
   return `require.register('${moduleName}', function(exports,req,module){
-    var require = __makeRequire((${r}), ${JSON.stringify(brMap)});
+    var require = __makeRequire((${r}), ${JSON.stringify(brMap)}, '${getModuleFullRootName(filePath)}');
     ${glob}(function(exports,require,module) {
       ${source}
     })(exports,require,module);
@@ -151,14 +159,49 @@ const slashes = string => string.replace(/\\/g, '/');
 
 const generateModuleName = filePath => {
   const rp = getModuleRootPath(filePath);
-  const mn = getModuleRootName(filePath) +
+  const mn = getModuleFullRootName(filePath) +
     (isMain(filePath) ? '' : filePath.replace(rp, '').replace('.js', ''));
 
   return slashes(mn);
 };
 
 const generateFileBasedModuleName = filePath => {
-  return slashes(getModuleRootName(filePath) + filePath.replace(getModuleRootPath(filePath), '').replace('.js', ''));
+  return slashes(getModuleFullRootName(filePath) + filePath.replace(getModuleRootPath(filePath), '').replace('.js', ''));
 };
 
-module.exports = {aliasDef, simpleShimDef, applyPackageOverrides, generateModule, generateModuleName, getModuleRootName};
+const makeRequire = (
+  `var __makeRequire = function(r, __brmap, pref) {
+      var none = {};
+      var tryReq = function(name, pref) {
+        var val;
+        try {
+          val = r(pref + '/node_modules/' + name);
+          return val;
+        } catch (e) {
+          if (e.toString().indexOf('Cannot find module') === -1) {
+            throw e;
+          }
+
+          if (pref.indexOf('node_modules') !== -1) {
+            var s = pref.split('/');
+            var i = s.lastIndexOf('node_modules');
+            var newPref = s.slice(0, i+2).join('/');
+            return tryReq(name, newPref);
+          }
+        }
+        return none;
+      };
+      return function(name) {
+        if (__brmap[name] !== undefined) name = __brmap[name];
+        name = name.replace(".js", "");
+        if (name[0] !== '.' && pref) {
+          var val = tryReq(name, pref);
+          if (val !== none) return val;
+        }
+        return r(name);
+      }
+    };
+  `
+);
+
+module.exports = {aliasDef, simpleShimDef, applyPackageOverrides, generateModule, generateModuleName, getModuleRootName, makeRequire};

--- a/lib/deppack/process.js
+++ b/lib/deppack/process.js
@@ -42,13 +42,7 @@ const processFiles = (config, root, files, processor) => {
     var global = window;
     ${shimDefs.join('\n')}${usesProcess ? '\nvar process;' : ''}
 
-    var __makeRequire = function(r, __brmap) {
-      return function(name) {
-        if (__brmap[name] !== undefined) name = __brmap[name];
-        name = name.replace(".js", "");
-        return r(name);
-      }
-    };
+    ${modules.makeRequire}
   `);
   files.forEach(processor);
   root.add(aliases.join('\n'));


### PR DESCRIPTION
This is going to allow to use v1 of some library in the app code, while
retaining the ability for some other dependency to rely on v2.

It works by generating module names like this for nested modules:
"some_dep/node_modules/conflicting_dep". In require, it tries to prepend
that prefix. If the require fails, it drops it and tries to require just
"dep".

The drawbacks of this iteration are the try-catch approach that first tries to load current_module/node_modules/required_module and falls back to required_module otherwise, but that could as well be improved at a later time.