### PR TITLE
Resolve paths to make glob matching work reliably

### DIFF
--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -2,6 +2,7 @@
 const debug = require('debug')('brunch:list');
 const EventEmitter = require('events').EventEmitter;
 const normalize = require('path').normalize;
+const resolve = require('path').resolve;
 const fcache = require('fcache');
 const Asset = require('./asset');
 const SourceFile = require('./source_file');
@@ -185,6 +186,7 @@ class FileList {
   }
 
   _change(path, compiler, linters, isHelper) {
+    path = resolve(path);
     const ignored = this.isIgnored(path);
     if (this.is('assets', path)) {
       if (!ignored) {
@@ -208,6 +210,7 @@ class FileList {
   }
 
   _unlink(path) {
+    path = resolve(path);
     const ignored = this.isIgnored(path);
     if (this.is('assets', path)) {
       if (!ignored) this.assets.splice(this.assets.indexOf(path), 1);


### PR DESCRIPTION
To (kind of) address #1044 (which is really due npm completely broken and their mislead "nested deps" policy imnsvho), and to have a clean separation between tooling, sources, and builds, I am using a setup that breaks with ```brunch``` default conventions on purpose with separated directories for
- the brunch installation (e.g. ```~/brunch-installation```), not in git
- the project source (e.g. ```~/brunch-source```), mounted read-only in continuous integration setup (aka ```app``` as per brunch default convention)
- the project build target (e.g. ```~/brunch-build```), mounted read/write in continuous integration setup (aka ```public``` as per brunch default convention)

Using ```anymatch``` glob in this setup fails, because ```brunch``` does not resolve paths. This leads to relative paths in the build that could never be matched successfully using globs like ```joinTo: 'app.js': [ '**/app/**.js', '!**/app/ignoremeplease/*.js']```:

```
DEBUG="brunch:*" ~/brunch-inst/node_modules/brunch/bin/brunch b
[...]
  brunch:watch add /var/home/istr/brunch-source/app/application.js +3ms
  brunch:list Reading ../brunch-source/app/application.js +0ms
  brunch:file Init ../brunch-source/app/application.js: isntModule=false isWrapped=true +1ms
  brunch:pipeline Compiling ../brunch-source/app/application.js @ JavaScriptCompiler +2ms
  brunch:modules Wrapping brunch-source/app/application @ commonjs +5ms
  brunch:list Compiled ../brunch-source/app/application.js +1ms
[...]
```

To make that work, this PR ```resolve()```s the paths having the nice side-effect that logging shows the absolute path to the sources in question, so you don't need to figure out by resolving the paths in your mind.

```
DEBUG="brunch:pipeline" ~/brunch-inst/node_modules/brunch/bin/brunch b
  brunch:pipeline Compiling /home/istr/brunch-source/app/application.js @ JavaScriptCompiler +0ms
  brunch:pipeline Compiling /home/istr/brunch-source/app/styles/main.scss @ SassCompiler +16ms
  brunch:pipeline Dependencies /home/istr/brunch-source/app/styles/main.scss @ SassCompiler +4ms
08 Feb 10:59:17 - info: compiled 2 files into 2 files, copied index.html in 387ms
```
