### PR TITLE
Don't create aliases for shims with proper names

### DIFF
--- a/lib/deppack/process.js
+++ b/lib/deppack/process.js
@@ -14,7 +14,7 @@ const insertGlobals = (config, root) => {
 const processFiles = (config, root, files, processor) => {
   const shimAliases = shims.getUsedShims().reduce((acc, x) => {
     const mod = modules.generateModuleName(shims.fileShims[x]);
-    if (mod) {
+    if (mod !== x) {
       acc[x] = mod;
     }
     return acc;


### PR DESCRIPTION
Should fix the issue mentioned in https://github.com/brunch/brunch/issues/1161#issuecomment-183551321

cc @razor-x

The dev mode off in prod build is a nice-to-have and will be added later