### PR TITLE
Do not try to resolve optional deps scanned from npm packages.

### DIFF
--- a/lib/deppack/explore.js
+++ b/lib/deppack/explore.js
@@ -4,6 +4,7 @@ const sysPath = require('path');
 const each = require('async-each');
 const detective = require('detective');
 const mediator = require('../mediator');
+const modules = require('./modules');
 const shims = require('./shims');
 const helpers = require('./helpers');
 const xBrowserResolve = require('./resolve');
@@ -34,7 +35,10 @@ const fileModsNotChanged = (file, mods) => {
 const isJs = (fileList, path) => fileList.find(path).type === 'javascript';
 
 const isVendor = helpers.isVendor;
+const isPackage = helpers.isPackage;
 const isApp = helpers.isApp;
+
+const getPackageDeps = path => modules.packageJson(sysPath.resolve(path)).dependencies || {};
 
 const envify = (source, map) => {
   if (source.indexOf('process.env.') !== -1) {
@@ -87,8 +91,9 @@ const exploreDeps = fileList => {
     if (path.indexOf('.json') !== -1) return Promise.resolve(x);
 
     const allDeps = isVendor(path) ? [] : detective(source);
+    const packageDeps = isPackage(path) ? getPackageDeps(path) : null;
     const usesProcess = isVendor(path) ? false : shims.shouldIncludeProcess(source);
-    const deps = isApp(path) ? allDeps.filter(x => !helpers.isRelative(x)) : allDeps;
+    const deps = isApp(path) ? allDeps.filter(x => !helpers.isRelative(x)) : isPackage(path) ? allDeps.filter(x => x in packageDeps) : allDeps;
 
     const resPath = sysPath.resolve(path);
     const res = (i, cb) => xBrowserResolve.resolve(i, {filename: resPath}, cb);

--- a/lib/deppack/modules.js
+++ b/lib/deppack/modules.js
@@ -216,4 +216,4 @@ const makeRequire = (
   `
 );
 
-module.exports = {aliasDef, simpleShimDef, applyPackageOverrides, generateModule, generateModuleName, getModuleRootName, makeRequire, cacheMain};
+module.exports = {aliasDef, simpleShimDef, applyPackageOverrides, generateModule, generateModuleName, getModuleRootName, makeRequire, cacheMain, packageJson};


### PR DESCRIPTION
Brunch build fails trying to resolve not installed optional deps from npm-installed dependency:

    19 Feb 12:14:24 - error: Resolving deps of node_modules/exoskeleton/exoskeleton.js failed. Could not load module 'underscore' from '[...]/node_modules/exoskeleton'. Possible solution: run `npm install`.


This happens when using exoskeleton without underscore. The line in `exoskeleton.js` that triggers the error is this:

    try { _ = require('underscore'); } catch(e) { }

The solution in this PR is to check scanned deps found in npm packages against the configured deps in the corresponding `package.json` file.

To restore the old behaviour one could add overrides to the main app's `package.json`. For the above example it would look like this:

    ...
    "overrides": {
      "exoskeleton": {
        "dependencies": {
          "underscore": "*"
        }
      }
    ...