### PR TITLE
Add support for module extensions

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -13,8 +13,7 @@ const cleanModuleName = exports.cleanModuleName = (path, nameCleaner) => {
 
 const getModuleWrapper = (type, nameCleaner) => {
   return (fullPath, data, isVendor) => {
-    const sourceURLPath = cleanModuleName(fullPath, nameCleaner);
-    const moduleName = sourceURLPath.replace(wrapperRe, '');
+    const moduleName = cleanModuleName(fullPath, nameCleaner);
     const path = JSON.stringify(moduleName);
     if (isVendor) {
       debug(`Not wrapping (is vendor file) ${moduleName}`);

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -23,7 +23,7 @@ const getModuleWrapper = (type, nameCleaner) => {
     /* Wrap in common.js require definition. */
     if (type === 'commonjs') {
       return {
-        prefix: 'require.register(' + path + ', function(exports, require, module, global) {\n',
+        prefix: 'require.register(' + path + ', function(exports, require, module) {\n',
         suffix: '});\n\n'
       };
     } else if (type === 'amd') {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -4,7 +4,6 @@ const commonRequireDefinition = require('commonjs-require-definition');
 
 const backslashRe = new RegExp('\\\\', 'g');
 const dotRe = new RegExp('^(\.\.\/)*', 'g');
-const wrapperRe = /\.\w+$/;
 const amdRe = /define\s*\(/;
 
 const cleanModuleName = exports.cleanModuleName = (path, nameCleaner) => {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -23,7 +23,7 @@ const getModuleWrapper = (type, nameCleaner) => {
     /* Wrap in common.js require definition. */
     if (type === 'commonjs') {
       return {
-        prefix: 'require.register(' + path + ', function(exports, require, module) {\n',
+        prefix: 'require.register(' + path + ', function(exports, require, module, global) {\n',
         suffix: '});\n\n'
       };
     } else if (type === 'amd') {


### PR DESCRIPTION
This is dependent on
https://github.com/brunch/commonjs-require-definition/pull/12.

This PR will allow the use of extensions in requiring module names such
as `require('./my-widget.html')`. It is just the minimum change to
allow this in the app code.

With the commonjs module change, `deppack/modules.js` might be made
simpler and more robust. The `package.json` “main” definition could use
aliases. Modules can be safely referenced with or without their
extensions. But I don’t feel comfortable making the changes required in
there yet.