### PR TITLE
Update detective to 4.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "source-map": "~0.5.0",
     "async-each": "~0.1.6",
     "browser-resolve": "~1.11.1",
-    "detective": "~4.0.0",
+    "detective": "~4.3.0",
     "glob": "~6.0.0",
     "node-browser-modules": "~0.1.0"
   },


### PR DESCRIPTION
Newer detective versions have only two dependencies instead of 13, and
should be slightly faster.