### PR TITLE
Fix regression introduced in GH-1184

### DIFF
--- a/lib/deppack/explore.js
+++ b/lib/deppack/explore.js
@@ -38,7 +38,16 @@ const isVendor = helpers.isVendor;
 const isPackage = helpers.isPackage;
 const isApp = helpers.isApp;
 
-const getPackageDeps = path => modules.packageJson(sysPath.resolve(path)).dependencies || {};
+const shouldIncludeDep = path => {
+  const currRoot = modules.getModuleRootName(path);
+  const pkg = modules.packageJson(sysPath.resolve(path));
+  const deps = pkg.dependencies || {};
+  return dep => {
+    const root = dep.split('/')[0];
+    // ignore optional dependencies
+    return (helpers.isRelative(dep) || root in deps || root === currRoot || root in shims.fileShims || shims.emptyShims.indexOf(root) !== -1);
+  };
+};
 
 const envify = (source, map) => {
   if (source.indexOf('process.env.') !== -1) {
@@ -91,9 +100,8 @@ const exploreDeps = fileList => {
     if (path.indexOf('.json') !== -1) return Promise.resolve(x);
 
     const allDeps = isVendor(path) ? [] : detective(source);
-    const packageDeps = isPackage(path) ? getPackageDeps(path) : null;
     const usesProcess = isVendor(path) ? false : shims.shouldIncludeProcess(source);
-    const deps = isApp(path) ? allDeps.filter(x => !helpers.isRelative(x)) : isPackage(path) ? allDeps.filter(x => x in packageDeps) : allDeps;
+    const deps = isApp(path) ? allDeps.filter(x => !helpers.isRelative(x)) : isPackage(path) ? allDeps.filter(shouldIncludeDep(path)) : allDeps;
 
     const resPath = sysPath.resolve(path);
     const res = (i, cb) => xBrowserResolve.resolve(i, {filename: resPath}, cb);


### PR DESCRIPTION
The PR failed to account for the fact that node modules can require:

a) relative paths (as in ./lib/React)
b) parts of themselves using their module name (as in a/b from module a)
c) shims

@paulmillr we probably should merge changes like this more carefully, probably by first testing if one of our react/exim apps builds and works fine.