### PR TITLE
Allow to specify again conventions.vendor as an anymatch set

### DIFF
--- a/lib/deppack/helpers.js
+++ b/lib/deppack/helpers.js
@@ -2,6 +2,7 @@
 
 const sysPath = require('path');
 const fs = require('fs');
+const anymatch = require('anymatch');
 const mediator = require('../mediator');
 
 const fsstat = require('../helpers').promisify(fs.stat);
@@ -16,7 +17,7 @@ const globalPseudofile = '___globals___';
 
 const packageRe = /node_modules/;
 const isPackage = path => packageRe.test(path) && (mediator.npm.static || []).indexOf(path) === -1;
-const isVendor = path => isPackage(path) ? false : mediator.conventions.vendor.test(path);
-const isApp = path => !mediator.conventions.vendor.test(path);
+const isVendor = path => isPackage(path) ? false : anymatch(mediator.conventions.vendor, path);
+const isApp = path => !anymatch(mediator.conventions.vendor, path);
 
 module.exports = {isDir, makeRelative, isRelative, not, globalPseudofile, isVendor, isApp, isPackage};


### PR DESCRIPTION
Per the docs, `conventions.vendor` can be set as an `anymatch` matcher but a small regression (comes from 0c1dec1dddff18664de40a52302d2d4814be6be9 it seems) made it Regex only.

This fix that by using anymatch again.

cc'ing @goshakkk just in case as he's the author of the aforementioned commit
