### PR TITLE
Align function as a wrapper with other types

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -11,7 +11,7 @@ const cleanModuleName = exports.cleanModuleName = (path, nameCleaner) => {
   return nameCleaner(path.replace(backslashRe, '/').replace(dotRe, ''));
 };
 
-const getModuleWrapper = (type, nameCleaner) => {
+const getModuleWrapper = (type, nameCleaner, wrapper) => {
   return (fullPath, data, isVendor) => {
     const sourceURLPath = cleanModuleName(fullPath, nameCleaner);
     const moduleName = sourceURLPath.replace(wrapperRe, '');
@@ -32,6 +32,10 @@ const getModuleWrapper = (type, nameCleaner) => {
       return {
         data: data.replace(amdRe, match => '' + match + path + ', ')
       };
+    } else if (type === 'function') {
+      return {
+        data: wrapper(sourceURLPath, data)
+      };
     }
   };
 };
@@ -48,7 +52,7 @@ const normalizeWrapper = (typeOrFunction, nameCleaner) => {
       };
     default:
       if (typeof typeOrFunction === 'function') {
-        return typeOrFunction;
+        return getModuleWrapper('function', nameCleaner, typeOrFunction);
       } else {
         throw new Error('config.modules.wrapper should be a ' +
           'function or one of: "commonjs", "amd", false');


### PR DESCRIPTION
Currently, when specifying `modules.wrapper` as a function, the `conventions.vendor` and `modules.nameCleaner` aren't respected.

This PR allow to :
- Not having to check if a file is a vendor one
- Not having to cleanup the module name manually