### PR TITLE
Fix a regression introduced with GH-1184

### DIFF
--- a/lib/deppack/explore.js
+++ b/lib/deppack/explore.js
@@ -44,8 +44,9 @@ const shouldIncludeDep = path => {
   const deps = pkg.dependencies || {};
   return dep => {
     const root = dep.split('/')[0];
+    const browser = typeof pkg.browser === 'object' ? pkg.browser : typeof pkg.browserify === 'object' ? pkg.browserify : {};
     // ignore optional dependencies
-    return (helpers.isRelative(dep) || root in deps || root === currRoot || root in shims.fileShims || shims.emptyShims.indexOf(root) !== -1);
+    return (helpers.isRelative(dep) || root in deps || browser[root] && browser[root] in deps || root === currRoot || root in shims.fileShims || shims.emptyShims.indexOf(root) !== -1);
   };
 };
 

--- a/lib/deppack/modules.js
+++ b/lib/deppack/modules.js
@@ -129,7 +129,7 @@ const expandedFilePath = filePath => {
 
 const isMain = filePath => getMainCached(filePath) === sysPath.resolve(expandedFilePath(filePath));
 
-const getNewHeader = (moduleName, source, filePath) => {
+const getNewHeader = (moduleName, source, filePath, origPath) => {
   const brMap = globalBrowserMappings(filePath);
 
   const p = filePath.replace(getModuleRootPath(filePath), '').replace('.json', '').replace('.js', '').split(sysPath.sep).slice(0, -1);
@@ -142,16 +142,18 @@ const getNewHeader = (moduleName, source, filePath) => {
 
   if (filePath.indexOf('.json') === -1) {
     const fbModuleName = generateFileBasedModuleName(filePath);
-    const fbAlias = (mediator.npm.noFileBased ? shims.shouldIncludeFileBasedAlias(moduleName) : isMain(filePath)) ?
+    const fbAlias = (mediator.npm.noFileBased ? shims.shouldIncludeFileBasedAlias(moduleName) : isMain(filePath) ?
       aliasDef(fbModuleName, moduleName) :
       '';
+    const fbModuleNameUnexp = generateFileBasedModuleName(origPath);
+    const fbAliasUnexp = mediator.npm.noFileBased ? '' : fbModuleNameUnexp !== fbModuleName ? aliasDef(fbModuleNameUnexp, moduleName) : '';
 
     return `require.register("${moduleName}", function(exports, require, module) {
       require = __makeRelativeRequire(require, ${JSON.stringify(brMap)}, '${getModuleFullRootName(filePath)}'${itemPath});
       ${glob}(function() {
         ${source}
       })();
-    });\n${fbAlias}\n`;
+    });\n${fbAlias}${fbAliasUnexp}\n`;
   } else {
     return `require.register("${moduleName}", function(exports, require, module) {
       module.exports = ${source};
@@ -163,7 +165,7 @@ const generateModule = (filePath, source) => {
   const expandedPath = expandedFilePath(filePath);
   const mn = generateModuleName(expandedPath);
 
-  return '  ' + getNewHeader(mn, source, expandedPath);
+  return '  ' + getNewHeader(mn, source, expandedPath, filePath);
 };
 
 const slashes = string => string.replace(/\\/g, '/');


### PR DESCRIPTION
Another #1184-related regression discovered: https://github.com/brunch/brunch/issues/1136#issuecomment-189225521

This PR introduces a check that will use the dependency also if it is present in the `browser` field of the package.json