### PR TITLE
Don't assume `peerDependencies` are optional

### DIFF
--- a/lib/deppack/explore.js
+++ b/lib/deppack/explore.js
@@ -41,7 +41,7 @@ const isApp = helpers.isApp;
 const shouldIncludeDep = path => {
   const currRoot = modules.getModuleRootName(path);
   const pkg = modules.packageJson(sysPath.resolve(path));
-  const deps = pkg.dependencies || {};
+  const deps = Object.assign({}, pkg.dependencies || {}, pkg.peerDependencies || {});
   return dep => {
     const root = dep.split('/')[0];
     const browser = typeof pkg.browser === 'object' ? pkg.browser : typeof pkg.browserify === 'object' ? pkg.browserify : {};


### PR DESCRIPTION
Reported in: #1209 

This is yet another regression related to GH-1184, which purpose was to
not raise errors when optional dependencies could not be found.