### PR TITLE
Ensure deppack require discovery is case-sensitive

### DIFF
--- a/lib/deppack/resolve.js
+++ b/lib/deppack/resolve.js
@@ -1,12 +1,14 @@
 'use strict';
 
+const sysPath = require('path');
 const browserResolve = require('browser-resolve');
 const glob = require('glob');
 const modules = require('./modules');
-const globalPseudofile = require('./helpers').globalPseudofile;
+const helpers = require('./helpers');
 const mediator = require('../mediator');
 const promisify = require('../helpers').promisify;
 const shims = require('./shims');
+const trueCasePath = require('true-case-path');
 
 let modMap;
 
@@ -43,36 +45,54 @@ const buildModMap = () => {
 };
 
 const resolveErrorRe = /Cannot find module '(.+)' from '(.+)'/;
+const friendlyRequireError = (mod, opts, err) => {
+  const topLevel = modules.getModuleRootName(mod);
+  if (resolveErrorRe.test(err.message)) {
+    const data = err.message.match(resolveErrorRe);
+    const mod = data[1];
+    const src = data[2];
+    const isGlob = opts.filename === helpers.globalPseudofile;
+    err = isGlob ? `Could not load global module '${mod}'.` : `Could not load module '${mod}' from '${src}'.`;
+
+    if (topLevel === '.' || topLevel === '..') {
+      err += ' Make sure the file actually exists.';
+    } else if (noPackage(topLevel)) {
+      err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
+    } else {
+      if (mediator.overrides[mod]) {
+        err += ' Possible solution: run `npm install` and check your overrides in package.json.';
+      } else {
+        err += ' Possible solution: run `npm install`.';
+      }
+    }
+  }
+
+  err = new Error(err);
+  err.code = 'Resolving deps';
+  return err;
+};
+
+const checkImproperCase = (mod, opts, res) => {
+  if (res !== trueCasePath(res)) {
+    const err = new Error(`Improperly-cased require: '${mod}' in ${opts.filename}`);
+    err.code = 'Resolving deps';
+    return err;
+  }
+};
 
 const resolve = (mod, opts, cb) => {
   Object.assign(opts, {packageFilter: modules.applyPackageOverrides, modules: modMap, extensions: ['.js', '.json']});
   mod = mediator.npm.aliases && mediator.npm.aliases[mod] || mod;
   browserResolve(mod, opts, (err, res) => {
     if (err) {
-      if (resolveErrorRe.test(err.message)) {
-        const data = err.message.match(resolveErrorRe);
-        const mod = data[1];
-        const src = data[2];
-        const topLevel = modules.getModuleRootName(mod);
-        const isGlob = opts.filename === globalPseudofile;
-        err = isGlob ? `Could not load global module '${mod}'.` : `Could not load module '${mod}' from '${src}'.`;
-
-        if (topLevel === '.' || topLevel === '..') {
-          err += ' Make sure the file actually exists.';
-        } else if (noPackage(topLevel)) {
-          err += ` Possible solution: add '${topLevel}' to package.json and \`npm install\`.`;
-        } else {
-          if (mediator.overrides[mod]) {
-            err += ' Possible solution: run `npm install` and check your overrides in package.json.';
-          } else {
-            err += ' Possible solution: run `npm install`.';
-          }
-        }
-      }
-      err = new Error(err);
-      err.code = 'Resolving deps';
-      return cb(err);
+      return cb(friendlyRequireError(mod, opts, err));
     }
+
+    const caseError = checkImproperCase(mod, opts, res);
+    if (caseError) {
+      return cb(caseError);
+    }
+
     cb(null, res);
   });
 };

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -255,7 +255,7 @@ class BrunchWatcher {
     }, error => {
       fileList.emit('bundled');
       if (!Array.isArray(error)) error = [error];
-      const canTryRecover = error.find(err => err.toString().indexOf('`npm install`') !== -1);
+      const canTryRecover = error.find(err => err.toString().indexOf('run `npm install`') !== -1);
 
       error.forEach(subError => logger.error(subError));
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "pushserve": "^1.0.0",
     "quickly-copy-file": "~1.0.0",
     "read-components": "~0.7.0",
-    "source-map": "~0.5.0"
+    "source-map": "~0.5.0",
+    "true-case-path": "~1.0.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Makes issue of duplicate files reported in #1198 impossible on case-insensitive filesystems by making sure the resolved and actual FS path case-match.