### PR TITLE
Check project dependencies when starting brunch

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -6,6 +6,7 @@ const chokidar = require('chokidar');
 const debug = require('debug')('brunch:watch');
 const speed = require('since-app-start');
 const serveBrunch = require('serve-brunch');
+const checkDeps = require('check-dependencies');
 
 const workers = require('./workers'); // close, init
 const fsUtils = require('./fs_utils');
@@ -56,6 +57,18 @@ const getWatchedPaths = (config) => {
 
 const setProp = (obj, name) => result => (obj[name] = result);
 
+const checkProjectDependencies = cfg => {
+  return checkDeps({ packageDir: cfg.paths.root }).then(out => {
+    if (out.depsWereOk === false) {
+      const pkgs = out.error.filter(x => x.indexOf(':') !== -1).map(x => x.split(':')[0]);
+      logger.info(`Using outdated versions of ${pkgs.join(', ')}, trying to update to match package.json versions`);
+      return application.install(cfg.paths.root, 'npm').then(() => cfg, () => cfg);
+    }
+
+    return cfg;
+  });
+};
+
 class BrunchWatcher {
   constructor(persistent, options, onCompile) {
     speed.profile('Created BrunchWatcher');
@@ -64,6 +77,7 @@ class BrunchWatcher {
     this._isFirstRun = true;
 
     application.loadConfig(persistent, options).then(setProp(this, 'config'))
+      .then(cfg => checkProjectDependencies(cfg))
       .then(cfg => {
         if (options.jobs) {
           workers.init(persistent, options, cfg);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "quickly-copy-file": "~1.0.0",
     "read-components": "~0.7.0",
     "source-map": "~0.5.0",
-    "true-case-path": "~1.0.2"
+    "true-case-path": "~1.0.2",
+    "check-dependencies": "~0.12.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
It will also automatically try to update dependencies to match
package.json.

Adds another 100ms or so (depending on package.json, obviously) to the startup time.