### PR TITLE
Use a qualified deppack.isNpmJSON call. Closes GH-1236

### DIFF
--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -3,7 +3,7 @@ const debug = require('debug')('brunch:file');
 const smap = require('source-map');
 const readFile = require('micro-promisify')(require('fcache').readFile);
 
-const isNpmJSON = require('deppack').isNpmJSON;
+const deppack = require('deppack');
 const helpers = require('../helpers'); // below
 
 const pipeline = require('./pipeline').pipeline;
@@ -116,7 +116,7 @@ class SourceFile {
     this.fileList = fileList;
     // treat json files from node_modules as javascript
     const first = compilers && compilers[0];
-    const type = first && first.type || isNpmJSON(path) && 'javascript';
+    const type = first && first.type || deppack.isNpmJSON(path) && 'javascript';
     const isntModule = isHelper || isVendor;
     const isWrapped = type === 'javascript' || type === 'template';
     this.path = path;


### PR DESCRIPTION
Since `isNpmJSON` is set dynamically after `loadInit` is called, our code should always call `deppack.xyz`, instead of importing just `xyz`.