### PR TITLE
Compilers JS exports

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -327,7 +327,16 @@ file watching library used in brunch.
 
 ## `onCompile`
 
-`Function`: Optional callback to be called every time brunch completes a compilation cycle. It is passed a `generatedFiles` array, as well as `changedAssets` array. Each member of `generatedFiles` array is an object with `path` (path of the compiled file) and `sourceFiles` (array of objects representing each source file), each member of `changedAssets` array is an object with `path` (original path of an asset) and `destinationPath` (path of an asset in the public directory).
+`Function`: Optional callback to be called every time brunch completes a compilation cycle. It is passed a `generatedFiles` array, as well as `changedAssets` array. Each member of `generatedFiles` array is an object with:
+
+* `path` — path of the compiled file
+* `sourceFiles` — array of objects representing each source file
+* `allSourceFiles` array of objects representing each source file — this one also includes files that don't belong to the original type (e.g. if a styles compiler adds a JS module, path would the the concated JS file, and one of the `allSourceFiles` will be a style file
+
+Each member of `changedAssets` array is an object with:
+
+* `path` — original path of an asset
+* `destinationPath` — path of an asset in the public directory
 
 Example
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -176,3 +176,41 @@ module.exports = UglifyOptimizer;
 ```
 
 See the [plugins page](http://brunch.io/plugins.html) for a list of plugins. Feel free to add new plugins by editing [plugins.json](https://github.com/brunch/brunch.github.io/blob/master/plugins.json) and sending a Pull Request.
+
+### JS exports
+
+Starting Brunch (2.x.x `<unreleased>`), it is possible for non-JS compilers to output JavaScript modules **in addition** to whatever they do.
+
+A use case could be a styles compiler with CSS modules support that allows you to do something like this:
+
+```stylus
+.button
+  margin: 0
+```
+
+```javascript
+var style = require('./button.styl');
+// ...
+
+// style.button will return the obfuscated class name (something like "_button_xkplk_42" perhaps)
+<div className={style.button}>...</div>
+```
+
+All compiler needs to do is return `exports` in addition to `{data, map}`:
+
+```javascript
+class MyCompiler {
+  compile(params) {
+    const path = params.path;
+    const data = params.data;
+
+    const compiled = magic(data);
+    const mapping = mappingMagic(data);
+    const exports = 'module.exports = ' + JSON.stringify(mapping) + ';'
+
+    return Promise.resolve({ data: compiled, exports });
+  }
+}
+```
+
+Note: exported JS will not be compiled or linter by any other plugin and its `require` statements will not be resolved. Make sure your exported JS is self-contained.

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -201,15 +201,15 @@ const optimize = (data, map, path, optimizers, sourceFiles) => {
 
 const jsTypes = ['javascript', 'template'];
 
-const generate = (path, sourceFiles, config, optimizers) => {
-  const type = sourceFiles.some(file => jsTypes.indexOf(file.type) >= 0) ?
+const generate = (path, targets, config, optimizers) => {
+  const type = targets.some(file => jsTypes.indexOf(file.type) >= 0) ?
     'javascript' : 'stylesheet';
   const foptim = optimizers.filter(optimizer => optimizer.type === type);
   const len = config.paths['public'].length + 1;
   const joinKey = path.slice(len);
   const typeConfig = config.files[type + 's'] || {};
   const joinToValue = (typeConfig.joinTo && typeConfig.joinTo[joinKey]) || {};
-  const sorted = sort(sourceFiles, config, joinToValue);
+  const sorted = sort(targets, config, joinToValue);
   const norm = config._normalized;
   const definition = type === 'javascript' ? norm.modules.definition : null;
   const cc = concat(
@@ -221,7 +221,7 @@ const generate = (path, sourceFiles, config, optimizers) => {
   const map = cc.map;
   const withMaps = map && config.sourceMaps;
   const mapPath = path + '.map';
-  return optimize(code, map, path, foptim, sourceFiles)
+  return optimize(code, map, path, foptim, targets)
     .then(data => {
       if (withMaps) {
         const mapRoute = config.sourceMaps === 'absoluteUrl' ?

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -102,10 +102,12 @@ const compilerChain = (previousPromise, compiler) => {
         }
         let compiled;
         let compilerDeps;
+        let jsExports;
         if (toString.call(result) === '[object Object]') {
           compiled = result.data;
           sourceMap = result.map;
           compilerDeps = result.dependencies;
+          jsExports = result.exports;
         } else {
           compiled = result;
         }
@@ -121,7 +123,8 @@ const compilerChain = (previousPromise, compiler) => {
             compiled: compiled,
             source: source,
             sourceMap: sourceMap,
-            path: path
+            path: path,
+            jsExports: jsExports
           });
         }, error => {
           return Promise.reject(prepareError('Dependency parsing', error));

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -21,10 +21,7 @@ const SourceNode = smap.SourceNode;
 
 const sMapRe = /^\)\]\}'/;
 
-const updateMap = (path, compiled, wrapped, sourceMap) => {
-  if (sourceMap) {
-    debug("Generated source map for '" + path + "' ");
-  }
+const wrappedNode = (path, compiled, wrapped, sourceMap) => {
   let prefix;
   let suffix;
   let wrapperContent;
@@ -56,6 +53,14 @@ const updateMap = (path, compiled, wrapped, sourceMap) => {
   if (suffix) node.add(suffix);
   node.source = path;
   node.setSourceContent(path, wrapperContent);
+  return node;
+};
+
+const updateMap = (path, compiled, wrapped, sourceMap) => {
+  if (sourceMap) {
+    debug("Generated source map for '" + path + "' ");
+  }
+  const node = wrappedNode(path, compiled, wrapped, sourceMap);
 
   // the supplied source map might contain more than one source file
   const addSource = path => readFile(path).then(content => {
@@ -66,14 +71,21 @@ const updateMap = (path, compiled, wrapped, sourceMap) => {
   return Promise.all(sources.map(addSource)).then(() => node);
 };
 
-const updateCache = (path, cache, error, result, wrap) => {
+const updateJsExportsNode = (path, jsExports, wrappedJsExports) => {
+  if (jsExports) {
+    return wrappedNode(path, jsExports, wrappedJsExports, null);
+  }
+};
+
+const updateCache = (path, cache, error, result, wrap, jsWrap) => {
   if (error != null) {
     cache.error = error;
     return cache;
   }
   if (result == null) {
     cache.error = null;
-    cache.data = null;
+    cache.targets = {};
+    cache.targets[cache.type] = { data: null, node: null };
     cache.compilationTime = Date.now();
     return cache;
   }
@@ -84,9 +96,13 @@ const updateCache = (path, cache, error, result, wrap) => {
   cache.dependencies = result.dependencies;
   cache.source = source;
   cache.compilationTime = Date.now();
-  cache.data = compiled;
   updateMap(path, compiled, wrapped, result.sourceMap).then(node => {
-    cache.node = node;
+    cache.targets = {};
+    cache.targets[cache.type] = { data: compiled, node: node };
+    if (result.jsExports && cache.type !== 'javascript') {
+      const jsNode = updateJsExportsNode(path, result.jsExports, jsWrap(result.jsExports));
+      cache.targets['javascript'] = { data: result.jsExports, node: jsNode, addon: true };
+    }
     return cache;
   });
 };
@@ -97,14 +113,14 @@ const makeWrapper = (wrapper, path, isWrapped, isntModule) => {
   };
 };
 
-const makeCompiler = (path, cache, linters, compilers, wrap) => {
+const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap) => {
   const normalizedPath = replaceBackSlashes(path);
   return () => {
     return pipeline(path, linters, compilers, cache.fileList)
       .then(data => {
-        return updateCache(normalizedPath, cache, null, data, wrap).then(() => null);
+        return updateCache(normalizedPath, cache, null, data, wrap, jsWrap).then(() => null);
       }, error => {
-        return updateCache(normalizedPath, cache, error, null, wrap).then(() => Promise.reject(error));
+        return updateCache(normalizedPath, cache, error, null, wrap, jsWrap).then(() => Promise.reject(error));
       });
   };
 };
@@ -120,20 +136,19 @@ class SourceFile {
     const isntModule = isHelper || isVendor;
     const isWrapped = type === 'javascript' || type === 'template';
     const wrap = makeWrapper(wrapper, path, isWrapped, isntModule);
+    const jsWrap = makeWrapper(wrapper, path, true, isntModule);
 
     this.path = path;
     this.type = type;
     this.source = '';
-    this.data = '';
-    this.node = null;
+    this.targets = {};
     this.dependencies = [];
     this.compilationTime = null;
     this.error = null;
     this.isHelper = isHelper;
     this.removed = false;
     this.disposed = false;
-    this.compile = makeCompiler(path, this, linters, compilers, wrap);
-
+    this.compile = makeCompiler(path, this, linters, compilers, wrap, jsWrap);
     debug(`Init ${path}: %s`, prettify({
       isntModule: isntModule,
       isWrapped: isWrapped

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -10,32 +10,33 @@ const generate = require('./generate');
 // For use in `.filter()`.
 const changedSince = startTime => generated => {
   const g = generated;
-  return g.sourceFiles.some(f => f.compilationTime >= startTime || f.removed);
+  return g.allSourceFiles.some(f => f.compilationTime >= startTime || f.removed);
 };
 
 const formatWriteError = sourceFile => {
   return formatError(sourceFile.error, sourceFile.path);
 };
 
-const getPaths = (sourceFile, joinConfig) => {
-  const sourceFileJoinConfig = joinConfig[sourceFile.type + 's'] || {};
+const getPaths = (type, isHelper, path, joinConfig) => {
+  const sourceFileJoinConfig = joinConfig[type] || {};
   const hlprs = sourceFileJoinConfig.pluginHelpers;
   return Object.keys(sourceFileJoinConfig)
   .filter(key => {
     return key !== 'pluginHelpers';
   })
   .filter(generatedFilePath => {
-    if (sourceFile.isHelper) {
+    if (isHelper) {
       return hlprs.indexOf(generatedFilePath) >= 0;
     } else {
       const checker = sourceFileJoinConfig[generatedFilePath];
-      return checker(sourceFile.path);
+      return checker(path);
     }
   });
 };
 
 const getFiles = (fileList, config, joinConfig, startTime) => {
-  const map = {};
+  const _targetMap = {};
+  const _sourceMap = {};
   const anyJoinTo = {};
   const checkAnyJoinTo = file => {
     const ftype = file.type;
@@ -71,27 +72,50 @@ const getFiles = (fileList, config, joinConfig, startTime) => {
     }
   };
   fileList.files.forEach(file => {
-    if (file.error == null && file.data == null) return;
-    const paths = getPaths(file, joinConfig);
-    paths.forEach(path => {
-      if (map[path] == null) map[path] = [];
-      map[path].push(file);
-    });
-    if (!paths.length) {
-      if (file.error) logger.error(formatWriteError(file));
-      if (file.data && file.compilationTime >= startTime) {
-        if (!checkAnyJoinTo(file)) {
-          logger.warn(`${file.path} compiled, but not written. ` +
-            `Check your ${file.type}s.joinTo config`);
+    Object.keys(file.targets).forEach(type => {
+      const mainTarget = file.type === type;
+      const target = file.targets[type];
+      if (file.error == null && target.data == null) return;
+      const paths = getPaths(type + 's', file.isHelper, file.path, joinConfig);
+
+      // we check & print the warning only when bundling a stylesheet as a stylesheet, for example
+      // not when addings stylesheet's js code to the js bundle
+      if (mainTarget && paths.length === 0) {
+        if (file.error) logger.error(formatWriteError(file));
+        if (target.data && file.compilationTime >= startTime) {
+          if (!checkAnyJoinTo(file)) {
+            logger.warn(`${file.path} compiled, but not written. ` +
+              `Check your ${file.type}s.joinTo config`);
+          }
         }
       }
-    }
+
+      paths.forEach(path => {
+        if (_targetMap[path] == null) _targetMap[path] = [];
+        if (_sourceMap[path] == null) _sourceMap[path] = [];
+        const targetObj = {
+          path: file.path,
+          data: target.data,
+          node: target.node,
+          type: type,
+          source: mainTarget ? file.source : target.data
+        };
+        _targetMap[path].push(targetObj);
+        _sourceMap[path].push(file);
+      });
+    });
   });
-  return Object.keys(map).map(generatedFilePath => {
-    const sourceFiles = map[generatedFilePath];
+
+  return Object.keys(_targetMap).map(generatedFilePath => {
+    const targets = _targetMap[generatedFilePath];
+    const sourceFiles = _sourceMap[generatedFilePath];
+    const type = targets[0] && targets[0].type;
+    const legacySourceFiles = !type ? [] : sourceFiles.filter(f => f.type === type);
     const fullPath = sysPath.join(config.paths['public'], generatedFilePath);
     return {
-      sourceFiles: sourceFiles,
+      allSourceFiles: sourceFiles,
+      sourceFiles: legacySourceFiles,
+      targets: targets,
       path: fullPath
     };
   });
@@ -99,6 +123,7 @@ const getFiles = (fileList, config, joinConfig, startTime) => {
 
 const write = (fileList, config, joinConfig, optimizers, startTime) => {
   const files = getFiles(fileList, config, joinConfig, startTime);
+
   const errors = files
     .map(generated => {
       return generated.sourceFiles
@@ -118,11 +143,9 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
     sourcePaths: []
   };
   changed.forEach(generated => {
-    const sourceFiles = generated.sourceFiles;
+    const sourceFiles = generated.allSourceFiles;
     sourceFiles
-      .filter(file => {
-        return file.removed;
-      })
+      .filter(file => file.removed)
       .forEach(file => {
         disposed.generated.push(generated);
         disposed.sourcePaths.push(sysPath.basename(file.path));
@@ -132,7 +155,7 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
   });
 
   const gen = file => {
-    return generate(file.path, file.sourceFiles, config, optimizers);
+    return generate(file.path, file.targets, config, optimizers);
   };
 
   return Promise.resolve(changed)


### PR DESCRIPTION
Allows non-JS compilers to additionally expose a JS version of a file (use case: CSS modules, the compiler needs to both pre-process the source file + obfuscate class name, as well as create a JS module with class name mappings)

To achieve that, plugins that used to return `{data, map}` can now return `{data, map, exports}` where `exports` is a string containing javascript code:

```javascript
class MyCompiler {
  compile(params) {
    const path = params.path;
    const data = params.data;

    const compiled = magic(data);
    const exports = "module.exports = 42";

    return Promise.resolve({ data: compiled, exports });
  }
}
```

Internally it is achieved by allowing a single file have multiple *targets* — at max, one per file type (javascript, stylesheet, template), which is enough to get the example above working. It's not public API so should we need more flexible architecture some time later, we can also have multiple outputs of the same file type or something.

A less flexible option would be to hardcode store `jsExports` on source file, which also requires more code to make this "special case" work. (See fa762b8 for hardcoded jsExports vs targets)

To do:

- [x] allow plugins to emit JS modules for non-JS files
- [x] introduce the notion of targets internally
- [x] check if existing APIs were not affected:
  - [x] `onCompile` callback and the `sourceFiles` it receives (without JS-exported ones; create and document a new attribute for these in the callback))
  - [x] make sure resolving file's dependencies still works
- [x] document the `onCompile` callback changes
- [x] document the plugin API changes
- [x] make sure changing a style file also causes its JS exports to update
- [x] update brunch-maintained style plugins to have an option to produce CSS modules + JS exports with mappings:
  - [x] css-brunch https://github.com/brunch/css-brunch/pull/8
  - [x] stylus-brunch https://github.com/brunch/stylus-brunch/pull/43
  - [x] less-brunch https://github.com/brunch/less-brunch/pull/27
  - [x] sass-brunch https://github.com/brunch/sass-brunch/pull/104