### PR TITLE
Fix a regression introduces by 48cb5e0. Closes GH-1239

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -22,12 +22,14 @@ const mediator = {};
 const defaultConfigFilename = 'brunch-config';
 const defaultServerFilename = 'brunch-server';
 
-const customDeepAssign = (object, properties) => {
+const customDeepAssign = (object, properties, files) => {
+  const nestedObjs = Object.keys(files).map(file => files[file]);
+  const dontMerge = nestedObjs.indexOf(object) !== -1;
   Object.keys(properties).forEach(key => {
     const value = properties[key];
-    if (toString.call(value) === '[object Object]') {
+    if (toString.call(value) === '[object Object]' && !dontMerge) {
       if (object[key] == null) object[key] = {};
-      customDeepAssign(object[key], value);
+      customDeepAssign(object[key], value, files);
     } else {
       object[key] = value;
     }
@@ -74,7 +76,7 @@ const applyOverrides = (config, options) => {
         }));
       }
     });
-    customDeepAssign(config, overrideProps);
+    customDeepAssign(config, overrideProps, config.files);
   });
   return config;
 };


### PR DESCRIPTION
The old and documented behavior is that overrides of files[type].key
should completely overwrite the said part of the main config, not be
merged with it.