### PR TITLE
Add plugins' includes as npm.statics

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -83,7 +83,7 @@ const applyOverrides = (config, options) => {
 
 const deepFreeze = object => {
   Object.keys(Object.freeze(object))
-    .map(key => object[key])
+    .map(key => object[key] && object[key] !== object.static)
     .filter(value => {
       return value && typeof value === 'object' && !Object.isFrozen(value);
     })
@@ -296,6 +296,7 @@ const setConfigDefaults = exports.setConfigDefaults = (config, configPath) => {
   if (ar.enabled == null) ar.enabled = false;
   const npm = config.npm != null ? config.npm : config.npm = {};
   if (npm.enabled == null) npm.enabled = true;
+  if (npm.static == null) npm.static = [];
   return config;
 };
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -126,8 +126,11 @@ class BrunchWatcher {
     // Wish it worked like `watcher.add includes`.
     const rootPath = cfg.paths.root;
     this.plugins.includes.forEach(path => {
-      this.changeFileList(getRelativePath(rootPath, path), true);
+      const relPath = getRelativePath(rootPath, path);
+      cfg.npm.static.push(relPath);
+      this.changeFileList(relPath, true);
     });
+    Object.freeze(cfg.npm.static);
 
     if (cfg.persistent && cfg.stdin) {
       process.stdin.on('end', () => process.exit(0));


### PR DESCRIPTION
This is to let deppack distinguish between modules and vendor files that
just happen to come from node_modules.

Reported in: https://github.com/brunch/with-react/issues/3

Partly related to: https://github.com/brunch/brunch/issues/1247 & https://github.com/brunch/deppack/pull/1