### PR TITLE
Fix parent recompilation when a dependency changes

### DIFF
--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -121,13 +121,13 @@ class FileList extends EventEmitter {
     path = normalizePath(path);
     const paths = [];
     const parents = [];
-    this.files.forEach((dependent, path) => {
+    this.files.forEach((dependent, fpath) => {
       const deps = dependent.dependencies;
       const isDep = deps && deps.length > 0 &&
         deps.indexOf(path) >= 0 &&
-        !this.compiled.has(path);
+        !this.compiled.has(fpath);
       if (!isDep) return;
-      paths.push(path);
+      paths.push(fpath);
       parents.push(dependent);
     });
     if (!parents.length) return;


### PR DESCRIPTION
(ref brunch/stylus-brunch#34)

This is a regression caused by the move to using `Map`s for
`fileList.files`. The `compileDependencyParents` function iterated over
`fileList`, shadowing the children's `path` with that of the file being
iterated.