### PR TITLE
Fix TypeError: file.dispose is not a function

### DIFF
--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -225,7 +225,8 @@ class FileList extends EventEmitter {
   dispose() {
     this.removeAllListeners();
     clearTimeout(this.timer);
-    this.assets.concat(this.files).forEach(file => file.dispose());
+    this.files.forEach(file => file.dispose());
+    this.assets.forEach(file => file.dispose());
     ['compiling', 'copying', 'compiled', 'files'].forEach(k => {
       this[k].clear();
       this[k] = null;


### PR DESCRIPTION
Hi there, thanks for this great project!

This PR fix an issue introduced in df88f11f4985fa3f94676e825b3e348fcebb6bfd.
While `this.files` has a `forEach` method, it's a `Map` instance so `this.assets.concat(this.files).forEach(file => file.dispose());` gives

```sh
TypeError: file.dispose is not a function
  at /home/marcio/n/lib/node_modules/brunch/lib/fs_utils/file_list.js:228:57
  at Array.forEach (native)
  at FileList.dispose (/home/marcio/n/lib/node_modules/brunch/lib/fs_utils/file_list.js:228:36)
  at Server.restart (/home/marcio/n/lib/node_modules/brunch/lib/watch.js:204:21)
  at Server.g (events.js:261:16)
  at emitNone (events.js:68:13)
  at Server.emit (events.js:167:7)
  at emitCloseNT (net.js:1525:8)
  at nextTickCallbackWith1Arg (node.js:444:9)
  at process._tickCallback (node.js:366:17)
```

This happen when running `brunch w -s` and afterward editing the package.json.