### PR TITLE
Call isNpmJSON directly from the deppack object to prevent undefined …

### DIFF
--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -6,7 +6,7 @@ const _smap = require('source-map');
 const SourceMapConsumer = _smap.SourceMapConsumer;
 const SourceNode = _smap.SourceNode;
 
-const isNpmJSON = require('deppack').isNpmJSON;
+const deppack = require('deppack');
 const pipeline = require('./pipeline').pipeline;
 
 const _helpers = require('../helpers'); // below
@@ -121,7 +121,7 @@ class SourceFile {
     this.fileList = fileList;
     // treat json files from node_modules as javascript
     const first = compilers && compilers[0];
-    const type = first && first.type || isNpmJSON(path) && 'javascript';
+    const type = first && first.type || deppack.isNpmJSON(path) && 'javascript';
     const isntModule = isHelper || isVendor;
     const isWrapped = type === 'javascript' || type === 'template';
     const wrap = makeWrapper(wrapper, path, isWrapped, isntModule);


### PR DESCRIPTION
…error

deppack assigns to [itself some methods](https://github.com/brunch/deppack/blob/master/index.js) when the configuration is loaded for the first time. 
Using the reference for `isNpmJSON` in the file top level returns undefined, since `deppack.loadInit` was not called. I changed the code to call the method directly from the deppack object to prevent this race condition issue.

