### PR TITLE
Fix a regression introduced by JS exports

### DIFF
--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -85,7 +85,8 @@ const getFiles = (fileList, config, joinConfig) => {
     const targets = _targetMap[generatedFilePath];
     const sourceFiles = targets.map(target => target.file);
     const type = targets[0] && targets[0].type;
-    const legacySourceFiles = !type ? [] : sourceFiles.filter(f => f.type === type);
+    const isJs = type => type === 'javascript' || type === 'template';
+    const legacySourceFiles = !type ? [] : sourceFiles.filter(f => f.type === type || (isJs(f.type) && isJs(type)));
     const fullPath = sysPath.join(config.paths['public'], generatedFilePath);
     return {
       allSourceFiles: sourceFiles,

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -83,16 +83,14 @@ const getFiles = (fileList, config, joinConfig) => {
 
   return Object.keys(_targetMap).map(generatedFilePath => {
     const targets = _targetMap[generatedFilePath];
-    const sourceFiles = targets.map(target => target.file);
+    const allSourceFiles = targets.map(target => target.file);
     const type = targets[0] && targets[0].type;
     const isJs = type => type === 'javascript' || type === 'template';
-    const legacySourceFiles = !type ? [] : sourceFiles.filter(f => f.type === type || (isJs(f.type) && isJs(type)));
-    const fullPath = sysPath.join(config.paths['public'], generatedFilePath);
-    return {
-      allSourceFiles: sourceFiles,
-      sourceFiles: legacySourceFiles,
-      targets, type, path: fullPath
-    };
+    const sourceFiles = type ?
+      allSourceFiles.filter(f => f.type === type || (isJs(f.type) && isJs(type))) :
+      [];
+    const path = sysPath.join(config.paths.public, generatedFilePath);
+    return {allSourceFiles, sourceFiles, path, targets, type};
   });
 };
 


### PR DESCRIPTION
Due to it, the parameters for the `sourceFiles` of `onCompile` callback
didn't retain properly the old behavior - template files would be
discarded from it. This commit is to address that issue.

The issue has caused some plugins, notably `static-jade-brunch` to stop functioning.