### PR TITLE
Don't categorize node_modules as 'assets' even if they match the regexp

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,8 @@ const coffee = require('coffee-script');
 const debug = require('debug')('brunch:config');
 const deepAssign = require('deep-assign');
 
-const loadInit = require('deppack').loadInit;
+const deppack = require('deppack'); // isNpm
+const loadInit = deppack.loadInit;
 const mdls = require('./modules');
 
 const _helpers = require('./helpers');
@@ -428,7 +429,14 @@ const normalizeConfig = config => {
   normalized.modules.autoRequire = mod.autoRequire;
   normalized.conventions = {};
   Object.keys(config.conventions).forEach(name => {
-    return normalized.conventions[name] = normalizeChecker(config.conventions[name]);
+    const fn = normalizeChecker(config.conventions[name]);
+    if (name === 'assets') {
+      normalized.conventions[name] = x => {
+        return deppack.isNpm(x) ? false : fn(x);
+      };
+    } else {
+      normalized.conventions[name] = fn;
+    }
   });
   normalized.paths = Object.assign({}, config.paths);
   normalized.paths.possibleConfigFiles = Object.keys(require.extensions).map(ext => {


### PR DESCRIPTION
Closes GH-1289