### PR TITLE
Added support to pass custom command line args with `--`.

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -31,6 +31,7 @@ program.command('build [path]')
   .option('-p, --production', 'same as `--env production`')
   .option('-d, --debug [pattern]', 'print verbose debug output to stdout')
   .option('-j, --jobs [num]', 'parallelize the build')
+  .option('--', 'separates and passes the remaining parameters to your brunch-config script')
   .action(commands.build);
 
 program.command('watch [path]')
@@ -42,6 +43,7 @@ program.command('watch [path]')
   .option('-d, --debug [pattern]', 'print verbose debug output to stdout')
   .option('-j, --jobs [num]', 'parallelize the build')
   .option('--stdin', 'listen to stdin and exit when stdin closes')
+  .option('--', 'separates and passes the remaining parameters to your brunch-config script')
   .action(commands.watch);
 
 const checkForRemovedOptions = (args, command) => {
@@ -85,7 +87,12 @@ exports.run = () => {
 
   const error = checkForRemovedOptions(args, command);
   if (error) return console.log(error);
-
+  
+  //Find the '--' parameter, and strip out the rest before passing it to the process.
+  var customArgsID = args.indexOf("--");
+  if(customArgsID>-1) args.splice(customArgsID, args.length);
+  
   program.parse(args);
+
   if (!validCommand) program.help();
 };

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -87,11 +87,11 @@ exports.run = () => {
 
   const error = checkForRemovedOptions(args, command);
   if (error) return console.log(error);
-  
+
   //Find the '--' parameter, and strip out the rest before passing it to the process.
-  var customArgsID = args.indexOf("--");
-  if(customArgsID>-1) args.splice(customArgsID, args.length);
-  
+  var customArgsID = args.indexOf('--');
+  if (customArgsID>-1) args.splice(customArgsID, args.length);
+
   program.parse(args);
 
   if (!validCommand) program.help();


### PR DESCRIPTION
This isn't a full ideal solution, but at least it allows the parameters past "--" to get leaked down to your custom script's `process.argv` array (includes the ones beforehand however, too).
Ideally these would be stored in some global / accessible property so that they can be easily obtained in a cleaned up array.

Example:

Call:

    brunch build -p -- "hello world"

Could then give you, ideally:

   exports.customArgs[0] == "hello world"

But for now you have to read the `process.argv` array manually and do what you want with it.