### PR TITLE
Hot Module Replacement API

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -41,6 +41,10 @@ files:
       'css/vendor.css': /^node_modules/
 ```
 
+## Does Brunch support Hot Module Replacement?
+
+Yes it does! Check out the [`hmr-brunch`](https://github.com/brunch/hmr-brunch) plugin for more details.
+
 ## How to use Bower?
 
 Brunch does support [Bower](http://bower.io), however NPM is becoming de-facto standard for front-end packages.

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -8,6 +8,8 @@ const mkdirp = promisify(require('mkdirp'));
 const deppack = require('deppack'); // needsProcessing, processFiles
 const helpers = require('../helpers'); // flatten, promisifyPlugin
 const processJob = require('../workers').processJob;
+const isHmrEnabled = require('../hmr').isEnabled;
+const hmrGenerate = require('../hmr').generate;
 
 const smap = require('source-map');
 const SourceMapConsumer = smap.SourceMapConsumer;
@@ -72,19 +74,14 @@ const sort = (files, config, joinToValue) => {
 const slashes = string => string.replace('\\', '/');
 
 const semi = ';';
-const concat = (files, path, definition, autoRequire, config) => {
+const concat = (files, path, definitionFn, autoRequire, config) => {
   if (autoRequire == null) autoRequire = [];
-  const isJs = !!definition;
+  const isJs = !!definitionFn;
 
   // nodes = files.map(toNode);
   const root = new SourceNode();
   const str = files.map(f => f.path).join(', ');
   debug(`Concatenating [${str}] => ${path}`);
-
-  const isNpm = config.npm.enabled ? deppack.needsProcessing : () => false;
-  const isntNpm = f => !isNpm(f);
-  const nonNpmFiles = files.filter(isntNpm);
-  const npmFiles = files.filter(isNpm);
 
   const processor = (file) => {
     root.add(file.node);
@@ -93,16 +90,37 @@ const concat = (files, path, definition, autoRequire, config) => {
     return root.setSourceContent(file.node.source, data);
   };
 
-  if (config.npm.enabled && isJs && npmFiles.length > 0) {
-    deppack.processFiles(root, npmFiles, processor);
-  }
-
-  nonNpmFiles.forEach(processor);
-
   if (isJs) {
-    root.prepend(definition(path, root.sourceContents));
+    const addRequire = req => root.add(`require('${slashes(req)}');`);
+
+    const isNpm = config.npm.enabled ? deppack.needsProcessing : () => false;
+    const isHmr = isHmrEnabled(config);
+
+    const moduleFiles = files.filter(f => isNpm(f) || f.file.isModule);
+    const nonModuleFiles = files.filter(f => moduleFiles.indexOf(f) === -1);
+
+    const definition = definitionFn(path, root.sourceContents);
+    const generateModuleFiles = () => {
+      if (config.npm.enabled && moduleFiles.length > 0) {
+        deppack.processFiles(root, moduleFiles, processor);
+      } else {
+        moduleFiles.forEach(processor);
+      }
+    };
+
+    const basicGenerate = (generateModuleFiles, nonModuleFiles, processor, deppack, definition, path, root) => {
+      root.add(definition);
+      generateModuleFiles();
+      nonModuleFiles.forEach(processor);
+    };
+
+    const generator = isHmr ? hmrGenerate : basicGenerate;
+    generator(generateModuleFiles, nonModuleFiles, processor, deppack, definition, path, root);
+
+    autoRequire.forEach(addRequire);
+  } else {
+    files.forEach(processor);
   }
-  autoRequire.forEach(req => root.add("require('" + slashes(req) + "');"));
   return root.toStringWithSourceMap({
     file: path
   });

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -135,6 +135,7 @@ class SourceFile {
     this.compilationTime = null;
     this.error = null;
     this.isHelper = isHelper;
+    this.isModule = !isntModule;
     this.removed = false;
     this.disposed = false;
     this.compile = makeCompiler(path, this, linters, compilers, wrap, jsWrap);

--- a/lib/hmr.js
+++ b/lib/hmr.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const sysPath = require('path');
+const logger = require('loggy');
+
+const isEnabled = config => config.hot && config.env.indexOf('production') === -1;
+
+const checkAutoReload = (cfg, plugins) => {
+  const hasAutoReload = plugins.compilers.find(compiler => compiler.brunchPluginName === 'auto-reload-brunch');
+  if (!hasAutoReload) {
+    throw new Error("Hot Module Reloading should only be used with 'auto-reload-brunch'");
+  } else if (!hasAutoReload.supportsHMR) {
+    throw new Error("Currently used version of 'auto-reload-brunch' does not support Hot Module Reloading");
+  }
+};
+
+const generate = (generateModuleFiles, nonModuleFiles, processor, deppack, definition, path, root) => {
+  const hmrFile = nonModuleFiles.find(x => x.path.indexOf(sysPath.join('hmr-brunch', 'runtime.js')) !== -1);
+  nonModuleFiles = nonModuleFiles.filter(f => f !== hmrFile);
+
+  if (hmrFile) {
+    processor(hmrFile);
+  } else {
+    logger.warn(`HMR runtime not found for ${path}. HMR only works if use compile your JS into a single file, could it be the case?`);
+  }
+
+  root.add(definition);
+
+  const depGraph = deppack.graph();
+  root.add(`require.hmr(${JSON.stringify(depGraph)}, function(require) {\n`);
+
+  generateModuleFiles();
+
+  root.add('});');
+  root.add('// hmr end');
+
+  nonModuleFiles.forEach(processor);
+};
+
+module.exports = {isEnabled, checkAutoReload, generate};

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -17,6 +17,7 @@ const fsUtils = require('./fs_utils');
 const application = require('./config'); // loadConfig, install
 const plugins = require('./plugins'); // init, isPluginFor
 const helpers = require('./helpers'); // asyncFilter, flatten, generateCompilationLog, getCompilationProgress
+const checkHmrAutoReload = require('./hmr').checkAutoReload;
 
 const fsExists = (path) => {
   return fsaccess(path).then(() => true, () => false);
@@ -108,6 +109,13 @@ class BrunchWatcher {
           serveBrunch.serve(cfg.server).then(setProp(this, 'server')),
           plugins.init(cfg, onCompile).then(setProp(this, 'plugins'))
         ]);
+      })
+      .then(() => {
+        const cfg = this.config;
+        const plugins = this.plugins;
+        if (cfg.hot) {
+          checkHmrAutoReload(cfg, plugins);
+        }
       })
       .then(() => this.initCompilation())
       .catch(error => {


### PR DESCRIPTION
To do: 

- [x] refactor
- [x] docs
- [x] actually reload the page if updates can't be applied (how to make sure the reason for the reload is kept? console is flushed on the reload)
- [x] update redux skeleton — https://github.com/brunch/with-redux/pull/2

After merged (in order):

- [x] release deppack
- [x] release commonjs-brunch
- [x] release auto-reload-brunch
- [x] bump deppack, commonjs; release brunch
- [ ] add `auto-reload-brunch` as `hmr-brunch`'s peerDep
- [x] release https://github.com/brunch/hmr-brunch
- [x] merge update for redux skeleton — https://github.com/brunch/with-redux/pull/2

What is intentionally missing from this PR:

- source maps for cases when `if (module.hot) { ... }` checks are cut — since production isn't going to need source maps anyway
- callback for self-accept `accept()` for when there is an error

Relevant PRs:

* [x] https://github.com/brunch/deppack/pull/19 (deppack changes needed to support)
* [x] https://github.com/brunch/commonjs-require-definition/pull/21 (HMR runtime code)
* [x] https://github.com/brunch/auto-reload-brunch/pull/70
- [x] https://github.com/brunch/with-redux/pull/2 (**only** after this is merged and all releases are cut)

---

http://github.com/brunch/hmr-brunch