### PR TITLE
Nitrous.io "Quickstart" Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Install Brunch with a simple node.js package manager command: `npm install -g br
 - To enable debug mode, simply pass `-d` flag to any command like that: `brunch build -d`
 - To create your own plugin, check out our [plugin boilerplate](https://github.com/brunch/brunch-boilerplate-plugin) as a starting point.
 
+## Nitrous Quickstart
+
+With [Nitrous.io](https://www.nitrous.io/) you can create a ready-made Brunch development environnment in just a few minutes at the click of a button.
+
+[Sign up](https://www.nitrous.io/app/#/signup) and [login](https://www.nitrous.io/app/#/login) to the Nitrous platform then click the button below to begin the Quickstart project creation process:
+
+[![Nitrous Quickstart](https://nitrous-image-icons.s3.amazonaws.com/quickstart.svg)](https://www.nitrous.io/quickstart?repo=https://github.com/brunch/brunch)
+
+For further detailed instructions on how to proceed - read through [this repository's Quickstart readme file](https://github.com/brunch/brunch/blob/master/nitrous.readme.md).
+
 ## License
 
 Brunch is released under the MIT License.

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+npm install -g brunch bower
+
+cd ~/code
+
+brunch new brunch-babel-es6 -s https://github.com/brunch/with-es6
+( cd ~/code/brunch-babel-es6 ; brunch build )
+
+brunch new brunch-exim-react -s https://github.com/hellyeahllc/brunch-with-exim
+( cd ~/code/brunch-exim-react ; brunch build )
+
+brunch new brunch-chaplin -s https://github.com/paulmillr/brunch-with-chaplin
+( cd ~/code/brunch-chaplin ; brunch build )

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,13 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "Brunch Development Environment",
+  "logo": "http://i.imgur.com/aePKLBU.png",
+  "description": "Ready made Nitrous project for creating all manner of Brunch web applications.",
+  "scripts": {
+    "Start Working Directory's Brunch Server": "brunch watch -s",
+    "Start brunch-babel-es6 Server": "cd ~/code/brunch-babel-es6 && brunch watch -s",
+    "Start brunch-exim-react Server": "cd ~/code/brunch-exim-react && brunch watch -s",
+    "Start brunch-chaplin Server": "cd ~/code/brunch-chaplin && brunch watch -s"
+  }
+}

--- a/nitrous.readme.md
+++ b/nitrous.readme.md
@@ -1,0 +1,68 @@
+# Nitrous Brunch Quickstart
+
+This `nitrous.readme.md` file contains instructions on how to use the Nitrous [Quickstart](https://www.nitrous.io/quickstarts/) feature with this project.
+
+Quickstarts allow you to create an out of the box development environment on Nitrous in just a few minutes; without having to perform the expected setup or configuration beforehand.
+
+## How to Use
+
+All that's required is a [Nitrous.io account](https://www.nitrous.io) and that your are signed in to this account with your web browser when you click the Quickstart trigger button below.
+
+Click the button to begin the process once signed in:
+
+[![Nitrous Quickstart](https://nitrous-image-icons.s3.amazonaws.com/quickstart.svg)](https://www.nitrous.io/quickstart?repo=https://github.com/brunch/brunch)
+
+> The Quick Start setup process will take several minutes to complete.
+
+After the process completes you are redirected to your new Brunch development environnment on Nitrous. An environment that's ready to use and build Brunch web applications from the get go.
+
+## Brunch Development on Nitrous
+
+>See the Brunch [documentation](https://github.com/brunch/brunch-guide), [readme](https://github.com/brunch/brunch/blob/master/README.md), and [official website](http://brunch.io/) for directions on how to develop Brunch apps in detail.
+
+There are some aspects of development specific to Nitrous that you should be aware of whilst using the platform.
+
+The first is that all test/preview server processes need to be run on the host address `0.0.0.0` - instead of the usual `localhost` or `127.0.0.1` addresses. The process must also be run on an open port number, which is `3000` on this Brunch Quickstart template.  
+
+So for each and any Brunch apps you want to preview you'll need to add this next function to your main Brunch configuration file:
+
+```javascript
+server: {
+ hostname: '0.0.0.0',
+ port: '3000'
+},
+```
+
+Real examples of this function being added to `brunch-config.js` and `brunch-config.coffee` are shown in the later steps of [this Nitrous Guide on Brunch](https://community.nitrous.io/tutorials/getting-started-with-brunch).
+
+This Quickstart template for Brunch also has several in-built "Run" functions that work as shortcuts to launching an app's preview server (once configured with the above).
+
+1 - Click the "Start Working Directory's Brunch Server" option (whilst inside a Brunch project) from the "Run" tab to start the server process.
+
+![Nitrous Run Menu](http://i.imgur.com/tS4yWvL.png)
+
+2 - Then click the "Preview" tab and "Port 3000" to see the application running in your browser.
+
+![Nitrous App Preview](http://i.imgur.com/KQHm6qN.png)
+
+As long as the server setting described earlier is included in the main config file, this should work as intended.
+
+Lastly on a separate note - please bear in mind that the Nitrous platform is intended primarily for use as a development environment, and not to function as a live production solution.
+
+## Brunch Quickstart Sample Projects
+
+There are three Brunch sample projects pre-installed onto this template, with all of their dependencies included. These are there for you to test, preview, or use for your own development should you wish to.
+
+These projects must also be configured to run on the correct hostname and port before attempting to Preview them on Nitrous (discussed above).
+
+1. `brunch-babel-es6` - a simple project that includes Babel/ES6 support as part of the template: [https://github.com/brunch/with-es6](https://github.com/brunch/with-es6)
+2. `brunch-exim-react` - provides the basis for a Brunch app that uses Exim and React as part of the development: [https://github.com/hellyemhllc/brunch-with-exim](https://github.com/hellyeahllc/brunch-with-exim)
+3. `brunch-chaplin` - example skeleton for creating Brunch web apps with the [Chaplin](http://chaplinjs.org/) framework: [https://github.com/paulmillr/brunch-with-chaplin](https://github.com/paulmillr/brunch-with-chaplin)
+
+To preview one of these sample projects at any time or place, click the relevant "Start Server" option from the "Run" tab to launch, then click the "Preview" tab and "Port 3000" to see the application running in your browser.
+
+## More Help
+
+* [Getting Started with Brunch Tutorial on Nitrous](https://community.nitrous.io/tutorials/getting-started-with-brunch) - Begin at step **"3 - Create a Basic Brunch Project"**.
+* [Previewing Your App on Nitrous](https://community.nitrous.io/docs/preview-your-app) - Context on the server preview configuration.
+* [Nitrous Documentation](https://community.nitrous.io/docs) - General and specific topics.


### PR DESCRIPTION
Hi Brunch!

Recently [Nitrous.io]( https://www.nitrous.io) have added a new feature to their platform named “Quickstarts”. This feature lets users create pre-configured development environments on the service at the click of a button. Nitrous are trying to set up these Quickstarts for users by requesting that projects like yourself host the Quickstart trigger buttons on your GitHub readme. 

This would mean that if a Nitrous user wants a dev environment all set up and ready to develop Brunch applications with - they can click the HTML button embedded on your readme, and then the Nitrous API creates one for them.

* https://www.nitrous.io/quickstarts/  - repositories so far we've got Quickstarts for. 

All that’s needed from yourselves is that you keep the three API configuration files (seen in these proposed changes) inside your repo's root, and also that you have the HTML trigger button embedded in the main `README.md` - for people to click (this is also included in these changes). 

Is this something you’d be up for helping us out with? It would really make using Brunch on the platform super easy. 

To be clear there’s not much you have to do on your end, except merge these changes into your master. We (likely me) would make any new pull requests to yourself in the future, to maintain or ensure that these three files are up to date. None of your actual project code on GitHub gets touched or is involved at any point. The files here simply tell the API what to do when the button is clicked by  a Nitrous user. 

Here’s some more links that might help explain:

* [Blog Post Explaining the Idea](https://community.nitrous.io/posts/nitrous-quickstarts)
* [Specifically How it Works](https://community.nitrous.io/docs/nitrous-quickstarts)

Any questions do ask. 

Thanks guys. 