### PR TITLE
Print a warning if 'entryPoints' key-values are flipped

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -220,7 +220,7 @@ const normalizePluginHelpers = (items, subCfg) => {
  *   templates: {'*': {'javascripts/app.js': checker2}}
  * }
  */
-const createJoinConfig = configFiles => {
+const createJoinConfig = (configFiles, paths) => {
   const types = Object.keys(configFiles);
 
   checkFilesKeys(configFiles);
@@ -258,6 +258,10 @@ const createJoinConfig = configFiles => {
       }
 
       Object.keys(fileCfg.entryPoints).forEach(target => {
+        const isTargetWatched = paths.watched.some(path => target.indexOf(path + '/') === 0);
+        if (!isTargetWatched) {
+          logger.warn(`The correct use of entry points is: \`'entryFile.js': 'outputFile.js'\`. You are trying to use '${target}' as an entry point, but it is probably an output file.`);
+        }
         const outFiles = Object.keys(fileCfg.entryPoints[target]);
         if (outFiles.some(out => joinConfig[type][out])) {
           logger.warn(`config.files.${type}.joinTo is already defined for '${target}', can't add an entry point`);
@@ -421,7 +425,7 @@ const warnAboutConfigDeprecations = config => {
 
 const normalizeConfig = config => {
   const normalized = {};
-  normalized.join = createJoinConfig(config.files);
+  normalized.join = createJoinConfig(config.files, config.paths);
   const mod = config.modules;
   normalized.modules = {};
   normalized.modules.wrapper = mdls.normalizeWrapper(mod.wrapper, config.modules.nameCleaner);


### PR DESCRIPTION
The entryPoints format is `entryPoint: outputFile`, and this PR is meant to provide a helpful error message if an user accidentally uses them in the wrong order (i.e. `outputFile: entryPoint`)