### PR TITLE
Fix duplicate dependencies in package.json

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -73,9 +73,7 @@ const loadPackages = (rootPath) => {
 
   // Also need to test if `brunch-plugin` is in dep’s package.json.
   const loadDeps = (prop, isDev) => {
-    const deps = Object.keys(prop || {});
-
-    return deps.filter(dependency => {
+    return prop.filter(dependency => {
       return dependency !== brunchPluginPattern &&
         dependency.indexOf(brunchPluginPattern) !== -1;
     }).map(dependency => {
@@ -98,12 +96,24 @@ const loadPackages = (rootPath) => {
     });
   };
 
-  const plugins = loadDeps(json.dependencies);
-  const devPlugins = loadDeps(json.devDependencies, true);
-  const optPlugins = loadDeps(json.optionalDependencies, true);
-  const allPlugins = plugins.concat(devPlugins, optPlugins);
+  const uniqueDeps = function(/*mainDeps, ...otherDeps*/) {
+    return slice.call(arguments, 0).map(deps => {
+      return Object.keys(deps || {});
+    }).map((dep, index, deps) => {
+      if (!index) { return dep; }
+      return dep.filter((dependency) => {
+        return deps[0].indexOf(dependency) === -1;
+      });
+    });
+  };
 
-  return allPlugins.filter(p => p);
+  return uniqueDeps(
+    json.dependencies,
+    json.devDependencies,
+    json.optionalDependencies
+  ).map((dependencies, index) => {
+    return loadDeps(dependencies, index !== 0);
+  }).reduce((acc, elem) => { return acc.concat(elem); }, []);
 };
 
 /* Load brunch plugins, group them and initialise file watcher.

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -100,9 +100,14 @@ const loadPackages = (rootPath) => {
     return slice.call(arguments, 0).map(deps => {
       return Object.keys(deps || {});
     }).map((dep, index, deps) => {
-      if (!index) { return dep; }
+      if (index === 0) { return dep; }
+      // return for mainDeps; filter otherDeps for finding plugins intersection with mainDeps.
       return dep.filter((dependency) => {
-        return deps[0].indexOf(dependency) === -1;
+        const depUnique = deps[0].indexOf(dependency) === -1;
+        if (!depUnique) {
+          logger.warn(`You have declared ${dependency} in both dependencies and devDependencies`);
+        }
+        return depUnique;
       });
     });
   };


### PR DESCRIPTION
Hello there!

I've found a bug with duplicating plugins in package.json. Imagine situation:

```javascript
"dependencies": {
  "my-cool-optimizer": "^0.0.1"
},
"devDependencies": {
  "my-cool-optimizer": "^2.0.0"
}
```

In this case, optimizer from my-cool-optimizer plugin would work two times. I think it is wrong, isn't it? And it can break _(and, actually, it break my build process)_ somebody build process if it is doing something with output (e.g. wrapping it).

**What do you think about it? Is it needed or I'm too captious?**

And, I think we need to have some _FAQ for developers_ - even starting from 'how to roll out dev env for contributing brunch' - because that loadBrunch && loadGlobalBrunch, which appeared recently, made my day for a while when I tried to debug brunch :)