### PR TITLE
Fix sourcemaps when using custom wrapper

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -31,9 +31,7 @@ const getModuleWrapper = (type, nameCleaner, wrapper) => {
         data: data.replace(amdRe, match => '' + match + path + ', ')
       };
     } else if (type === 'function') {
-      return {
-        data: wrapper(moduleName, data)
-      };
+      return wrapper(moduleName, data);
     }
   };
 };


### PR DESCRIPTION
Hello there.

Using custom wrapper I found that there is code inconsistency. 

Please, look at:
line **34** in modules.js _(method **getModuleWrapper**)_
line **34** in source_file.js _(method **wrappedNode**)_

Everything will work fine if we will return a string, but custom wrapper defined by function returns object { data: string } which breaks source map for that file, because **identityNode** is not expecting the code will go from different file than passed _path_ parameter to it. 

So, we need:
* either to refactor identity node
* or allow custom wrappers to return prefix and suffix itself
* or just look at this PR

What do you think, guys?