### PR TITLE
Config validation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,8 @@ const deppack = require('deppack'); // isNpm
 const loadInit = deppack.loadInit;
 const mdls = require('./modules');
 
+const skemata = require('skemata');
+
 const _helpers = require('./helpers');
 const isWindows = _helpers.isWindows;
 const replaceSlashes = _helpers.replaceSlashes;
@@ -22,6 +24,151 @@ coffee.register();
 const mediator = {};
 const defaultConfigFilename = 'brunch-config';
 const defaultServerFilename = 'brunch-server';
+
+const v = skemata.v;
+const defaultPort = 3333;
+const defaultInterval = 65;
+const configBaseSchema = v.object({
+  paths: v.object({
+    root: v.string.default('.'),
+    public: v.string.default('public'),
+    watched: v.array(v.string).default(['app', 'test', 'vendor']),
+    ignored: v.deprecated(v.noop, 'moved to `config.conventions.ignored`'),
+    assets: v.deprecated(v.noop, 'moved to `config.conventions.assets`'),
+    test: v.deprecated(v.noop, 'moved to `config.conventions.test`'),
+    vendor: v.deprecated(v.noop, 'moved to `config.conventions.vendor`'),
+    config: v.string,
+    packageConfig: v.string.default('package.json'),
+    bowerConfig: v.string.default('bower.json')
+  }).default({}),
+
+  rootPath: v.deprecated(v.noop, 'moved to `config.paths.root`'),
+  buildPath: v.deprecated(v.noop, 'moved to `config.paths.public`'),
+
+  files: v.objects({
+    keys: ['javascripts', 'templates', 'stylesheets'],
+    warner: key => {
+      if (['app', 'test', 'vendor', 'assets'].indexOf(key) !== -1) {
+        return 'was removed, use `config.paths.watched` instead';
+      }
+    }
+  }, v.object({
+    joinTo: v.either(
+      v.string,
+      v.objects({}, v.anymatch)
+    ),
+    entryPoints: v.objects({}, v.either(v.string, v.objects({}, v.anymatch))),
+    order: v.object({
+      before: v.anymatch,
+      after: v.anymatch
+    }),
+    pluginHelpers: v.either(v.string, v.array(v.string)),
+    defaultPaths: v.deprecated(v.noop, 'was removed'),
+    defaultExtensions: v.deprecated(v.noop, 'was removed')
+  })),
+
+  npm: v.object({
+    enabled: v.bool.default(true),
+    globals: v.objects({}, v.string),
+    styles: v.objects({}, v.array(v.string)),
+    static: v.array(v.string).default([])
+  }).default({}),
+
+  plugins: v.object({
+    on: v.array(v.string).default([]),
+    off: v.array(v.string).default([]),
+    only: v.array(v.string).default([])
+  }, false).default({}),
+
+  conventions: v.object({
+    ignored: v.anymatch.default([/[\\\/]_/, /vendor[\\\/](node|j?ruby-.*|bundle)[\\\/]/]),
+    assets: v.anymatch.default(/assets[\\\/]/),
+    vendor: v.anymatch.default(/(^bower_components|node_modules|vendor)[\\\/]/)
+  }).default({}),
+
+  modules: v.object({
+    wrapper: v.either(v.enum('commonjs', 'amd', false), v.function).default('commonjs'),
+    definition: v.either(v.enum('commonjs', 'amd', false), v.function).default('commonjs'),
+    autoRequire: v.objects({}, v.array(v.string)).default({}),
+    nameCleaner: v.function.default(path => path.replace(/^app\//, ''))
+  }).default({}),
+
+  notifications: v.bool.default(true),
+  notificationsTitle: v.string.default('Brunch'),
+
+  optimize: v.bool.default(false),
+  sourceMaps: v.either(v.bool, v.enum('old', 'absoluteUrl')).default(true),
+
+  server: v.object({
+    base: v.string.default(''),
+    port: v.int.default(defaultPort),
+    run: v.bool.default(false),
+    hostname: v.string.default('localhost'),
+    indexPath: v.string.default('index.html'),
+    noPushState: v.bool.default(false),
+    noCors: v.bool.default(false),
+    stripSlashes: v.bool.default(false),
+    path: v.string,
+    command: v.string
+  }).default({}),
+
+  fileListInterval: v.int.default(defaultInterval),
+
+  watcher: v.object({
+    usePolling: v.bool.default(false)
+  }).default({}),
+
+  hooks: v.object({
+    onCompile: v.function,
+    preCompile: v.function
+  }).default({}),
+
+  onCompile: v.deprecated(v.function, 'use `config.hooks.onCompile` instead'),
+  preCompile: v.deprecated(v.function, 'use `config.hooks.preCompile` instead')
+});
+
+const overrideSchema = v.merge(configBaseSchema, v.object({}), { ignoreFirstDefaults: true });
+const productionOverrideSchema = v.merge(
+  configBaseSchema,
+  v.object({
+    optimize: v.bool.default(true),
+    sourceMaps: v.either(v.bool, v.enum('old', 'absoluteUrl')).default(false),
+    overrides: v.deprecated(v.noop, "can't define 'overrides' inside an override"),
+
+    plugins: v.object({
+      autoReload: v.object({
+        enabled: v.bool.default(false)
+      }).default({})
+    }).default({})
+  }),
+  { ignoreFirstDefaults: true }
+).default({});
+
+const configSchema = v.merge(
+  configBaseSchema,
+  v.object({
+    overrides: v.objects({ specifics: { production: productionOverrideSchema } }, overrideSchema)
+  })
+);
+
+const validateConfig = config => {
+  const res = configSchema(config);
+  const fmt = skemata.formatObject(res, 'config');
+  if (fmt && fmt.errors.length > 0) {
+    fmt.errors.forEach(error => {
+      logger.error(`${error.path}: ${error.result}`);
+    });
+  }
+  if (fmt && fmt.warnings.length > 0) {
+    fmt.warnings.forEach(warn => {
+      logger.warn(`${warn.path}: ${warn.warning}`);
+    });
+  }
+  if (!res.ok) {
+    throw new Error('config is not valid');
+  }
+  return config;
+};
 
 const customDeepAssign = (object, properties, files) => {
   const nestedObjs = Object.keys(files).map(file => files[file]);
@@ -167,15 +314,6 @@ const replaceConfigSlashes = exports.replaceConfigSlashes = config => {
 // Returns Function.
 const normalizeChecker = anymatch;
 
-const checkFilesKeys = configFiles => {
-  const allowedFileTypes = ['javascripts', 'stylesheets', 'templates'];
-  const types = Object.keys(configFiles);
-
-  types.filter(type => allowedFileTypes.indexOf(type) === -1).forEach(type => {
-    logger.warn(`'${type}' is not an allowed 'files' key. You can only specify 'javascripts', 'stylesheets' or 'templates'.`);
-  });
-};
-
 const normalizeJoinConfig = joinTo => {
   // Can be used in `reduce` as `array.reduce(listToObj, {})`.
   const listToObj = (acc, elem) => {
@@ -222,8 +360,6 @@ const normalizePluginHelpers = (items, subCfg) => {
  */
 const createJoinConfig = (configFiles, paths) => {
   const types = Object.keys(configFiles);
-
-  checkFilesKeys(configFiles);
 
   const joinConfig = types.map(type => configFiles[type].joinTo)
     .map(joinTo => joinTo || {})
@@ -287,14 +423,6 @@ const createJoinConfig = (configFiles, paths) => {
   return Object.freeze(entryPoints);
 };
 
-const ensureType = (obj, key, type) => {
-  const item = obj[key];
-  const cls = typeof item;
-  const error = `config.paths[${key}] must be a ${type}`;
-  if (type === 'string' && cls !== 'string') throw new Error(error);
-  else if (type === 'array' && !Array.isArray(obj[key])) throw new Error(error);
-};
-
 const setConfigDefaults = exports.setConfigDefaults = (config, configPath) => {
   const join = (parent, name) => {
     return sysPath.join(config.paths[parent], name);
@@ -304,122 +432,35 @@ const setConfigDefaults = exports.setConfigDefaults = (config, configPath) => {
   };
 
   // Paths.
-  const paths = config.paths ? config.paths : config.paths = {};
+  const paths = config.paths;
 
-  if (paths.root == null) paths.root = '.';
-  ensureType(paths, 'root', 'string');
-
-  if (paths.public == null) paths.public = joinRoot('public');
-  ensureType(paths, 'public', 'string');
-
-  if (paths.watched == null) paths.watched = ['app', 'test', 'vendor'].map(joinRoot);
-
-  if (typeof paths.watched === 'string') paths.watched = [paths.watched];
-  ensureType(paths, 'watched', 'array');
+  paths.public = joinRoot(paths.public);
+  paths.watched = ['app', 'test', 'vendor'].map(joinRoot);
 
   if (paths.config == null) paths.config = configPath || joinRoot('config');
-  if (paths.packageConfig == null) paths.packageConfig = joinRoot('package.json');
-  if (paths.bowerConfig == null) paths.bowerConfig = joinRoot('bower.json');
+  paths.packageConfig = joinRoot(paths.packageConfig);
+  paths.bowerConfig = joinRoot(paths.bowerConfig);
 
   // Conventions.
-  const conventions = config.conventions != null ? config.conventions : config.conventions = {};
-  if (conventions.assets == null) conventions.assets = /assets[\\\/]/;
-  if (conventions.ignored == null) {
-    conventions.ignored = paths.ignored || [/[\\\/]_/, /vendor[\\\/](node|j?ruby-.*|bundle)[\\\/]/];
+  const conventions = config.conventions;
+  if (paths.ignored) {
+    conventions.ignored = paths.ignored;
   }
-  if (conventions.vendor == null) {
-    conventions.vendor = /(^bower_components|node_modules|vendor)[\\\/]/;
-  }
-
-  // General.
-  if (config.notifications == null) config.notifications = true;
-  if (config.sourceMaps == null) config.sourceMaps = true;
-  if (config.optimize == null) config.optimize = false;
-  if (config.plugins == null) config.plugins = {};
-
-  // Modules.
-  const cm = config.modules;
-  const modules = cm != null ?
-    cm === false ? config.modules = {wrapper: false, definition: false} : cm
-    : config.modules = {};
-  if (modules.wrapper == null) modules.wrapper = 'commonjs';
-  if (modules.definition == null) modules.definition = 'commonjs';
-  if (modules.nameCleaner == null) {
-    modules.nameCleaner = path => path.replace(/^app\//, '');
-  }
-  if (modules.autoRequire == null) modules.autoRequire = {};
 
   // Server.
-  const server = config.server != null ? config.server : config.server = {};
+  const server = config.server;
   server.publicPath = paths.public;
-  if (server.base == null) server.base = '';
-  if (server.port == null) server.port = 3333;
   if (server.run == null) server.run = false;
   if (!config.persistent) server.run = false;
 
   // Hooks.
-  if (config.hooks == null) config.hooks = {};
+  if (config.onCompile) {
+    config.hooks.onCompile = config.onCompile;
+  }
+  if (config.preCompile) {
+    config.hooks.preCompile = config.preCompile;
+  }
 
-  // Overrides.
-  const overrides = config.overrides != null ? config.overrides : config.overrides = {};
-  const production = overrides.production != null ? overrides.production : overrides.production = {};
-  if (production.optimize == null) production.optimize = true;
-  if (production.sourceMaps == null) production.sourceMaps = false;
-  if (production.plugins == null) production.plugins = {};
-  const pl = production.plugins;
-  if (pl.autoReload == null) pl.autoReload = {};
-  const ar = pl.autoReload;
-  if (ar.enabled == null) ar.enabled = false;
-  const npm = config.npm != null ? config.npm : config.npm = {};
-  if (npm.enabled == null) npm.enabled = true;
-  if (npm.static == null) npm.static = [];
-  return config;
-};
-
-const warnAboutConfigDeprecations = config => {
-  const messages = [];
-  const warnRemoved = path => {
-    if (config.paths[path]) {
-      return messages.push(`config.paths.${path} was removed, use config.paths.watched`);
-    }
-  };
-  const moveAndWarnAboutOnCompile = () => {
-    if (typeof config.onCompile === 'function') {
-      config.hooks.onCompile = config.onCompile;
-
-      messages.push('config.onCompile moved to config.hooks.onCompile');
-    }
-  };
-  const warnDefaultExtRemoved = () => {
-    Object.keys(config.files).forEach(type => {
-      if (config.files[type].defaultExtension) {
-        messages.push(`config.files.${type}.defaultPaths was removed`);
-      }
-    });
-  };
-  const warnMoved = (configItem, from, to) => {
-    if (configItem) {
-      return messages.push(`config.${from} moved to config.${to}`);
-    }
-  };
-  const ensureNotArray = name => {
-    if (Array.isArray(config.paths[name])) {
-      return messages.push(`config.paths.${name} can't be an array. Use config.conventions.${name}`);
-    }
-  };
-  warnRemoved('app');
-  warnRemoved('test');
-  warnRemoved('vendor');
-  warnRemoved('assets');
-  warnDefaultExtRemoved();
-  moveAndWarnAboutOnCompile();
-  warnMoved(config.paths.ignored, 'paths.ignored', 'conventions.ignored');
-  warnMoved(config.rootPath, 'rootPath', 'paths.root');
-  warnMoved(config.buildPath, 'buildPath', 'paths.public');
-  ensureNotArray('assets');
-  ensureNotArray('test');
-  ensureNotArray('vendor');
-  messages.forEach(msg => logger.warn(msg));
   return config;
 };
 
@@ -458,11 +499,6 @@ const normalizeConfig = config => {
   normalized.awaitWriteFinish = !!(config.watcher && config.watcher.awaitWriteFinish);
   normalized.isProduction = mediator.isProduction;
   config._normalized = normalized;
-  ['on', 'off', 'only'].forEach(key => {
-    if (typeof config.plugins[key] === 'string') {
-      return config.plugins[key] = [config.plugins[key]];
-    }
-  });
   return config;
 };
 
@@ -606,15 +642,14 @@ const tryToLoad = (configPath, fallbackHandler) => {
   });
 };
 
-const noop = (config) => config;
-
 exports.loadConfig = (persistent, opts, fromWorker) => {
+  const noop = (config) => config;
   const configPath = opts.config || defaultConfigFilename;
   const options = initParams(persistent, opts) || {};
   return tryToLoad(configPath)
+    .then(validateConfig)
     .then(config => setConfigDefaults(config, configPath))
     .then(fromWorker ? noop : addDefaultServer)
-    .then(fromWorker ? noop : warnAboutConfigDeprecations)
     .then(config => applyOverrides(config, options))
     .then(config => deepAssign(config, options))
     .then(replaceConfigSlashes)

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -133,9 +133,9 @@ const loadPackages = (rootPath) => {
 exports.init = (config, onCompile) => {
   speed.profile('Loaded config');
   logger.notifications = config.notifications;
-  logger.notificationsTitle = config.notificationsTitle || 'Brunch';
-  const black = config.plugins.off || [];
-  const white = config.plugins.only || [];
+  logger.notificationsTitle = config.notificationsTitle;
+  const black = config.plugins.off;
+  const white = config.plugins.only;
   const packages = loadPackages('.').filter(arg => {
     const brunchPluginName = arg.brunchPluginName;
     if (black.length && black.indexOf(brunchPluginName) >= 0) {
@@ -147,7 +147,7 @@ exports.init = (config, onCompile) => {
     }
   });
   const unfiltered = getPlugins(packages, config);
-  const alwaysP = config.plugins.on || [];
+  const alwaysP = config.plugins.on;
   const plugins = unfiltered.filter(plugin => {
 
     // Backward compatibility for legacy optimizers.
@@ -202,7 +202,7 @@ exports.init = (config, onCompile) => {
   });
 
   // Add preCompile callback from config.
-  if (typeof config.preCompile === 'function') {
+  if (typeof config.hooks.preCompile === 'function') {
     // => don't support arguments.
     preCompilers.push(new Promise((resolve, reject) => {
       if (config.preCompile.length === 1) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "deppack": "~0.4.0",
     "fcache": "~0.1.0",
     "init-skeleton": "~0.9.0",
+    "skemata": "~0.1.0",
     "loggy": "~0.3.0",
     "micro-promisify": "~0.1.0",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
This PR introduces config schema and types validation, as well as allows to centralize default values for various config keys via a simple descriptive DSL.

* errors and aborts brunch on incorrect types
* warns on deprecations
* warns on unrecognized `config.files` keys, for example, along with a list of possible values and suggestions

Sample error messages: 

<img width="1490" alt="screen shot 2016-04-21 at 2 42 02 pm" src="https://cloud.githubusercontent.com/assets/315596/14761985/f2f86fe6-0977-11e6-81be-f9d50a390ed7.png">

### A few (possibly breaking) changes

* `config.paths.watched` won't be coerced into an array if string. probably ok nevertheless since the type mismatch error will tell it should be an array

`config.modules = false` won't be possible... but then, it is not even documented, which means it shouldn't be relied up

`config.paths.*` will now always be relative to root. The current behavior is that if custom paths aren't specified, then they are joined with root, but custom paths *are not*. Seems a little inconsistent and all paths, default or custom, will now be relative to root.

for consistency, `preCompile` is also moved into `config.hooks.preCompile`, in line with `config.hooks.onCompile`

### To do

- [x] squash
- [ ] release skemata v0.1.0 https://github.com/brunch/skemata @paulmillr 