### PR TITLE
Allow .js files from node_modules/ to be compiled

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -142,6 +142,7 @@ npm: {
 * `off`: Plugins that may be installed, but should not be run.
 * `on`: Forces listed plugins to be run, such as an optimizer even when the `optimize` flag is off.
 * `only`: Explicitly list the plugins to be used, ignoring any others that are installed.
+* `npm`: An array list of plugin names that will compile `node_modules/`. Defaults to `['babel-brunch']`. *(Note: for the time being, it works **only** with `.js` files)*
 * _Per-Plugin_: Refer to each plugin's documentation for usage information.
 
 Example:

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,7 +77,8 @@ const configBaseSchema = v.object({
   plugins: v.object({
     on: v.array(v.string).default([]),
     off: v.array(v.string).default([]),
-    only: v.array(v.string).default([])
+    only: v.array(v.string).default([]),
+    npm: v.array(v.string).default(['babel-brunch'])
   }, false).default({}),
 
   conventions: v.object({

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -38,6 +38,7 @@ class FileList extends EventEmitter {
     this.conventions = norm.conventions;
     this.moduleWrapper = norm.modules.wrapper;
     this.configPaths = norm.paths.allConfigFiles;
+    this.depCompilers = config.plugins.npm;
 
     this.files = new Map();
     this.assets = [];
@@ -171,7 +172,7 @@ class FileList extends EventEmitter {
     const isVendor = this.is('vendor', path);
     const wrapper = this.moduleWrapper;
     const file = new SourceFile(
-      normalizePath(path), compiler, linters, wrapper, isHelper, isVendor, this
+      normalizePath(path), compiler, linters, wrapper, isHelper, isVendor, this, this.depCompilers
     );
     this.files.set(file.path, file);
     return file;

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -1,4 +1,5 @@
 'use strict';
+const sysPath = require('path');
 const logger = require('loggy');
 const debug = require('debug')('brunch:pipeline');
 const promisify = require('micro-promisify');
@@ -153,11 +154,34 @@ const CompileJob = {
   }
 };
 
-exports.pipeline = (path, linters, compilers, fileList) => {
+exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
   if (deppack.isNpm(path)) {
-    return deppack.wrapInModule(path).then(source => {
-      return {compiled: source, source, path};
-    }).then(deppack.exploreDeps(fileList));
+    const _path = sysPath.resolve('.', path);
+    const selectedLinters = [];
+    let selectedCompilers = [];
+
+    if (depCompilers.length) {
+      selectedCompilers = compilers.filter(comp => {
+        return depCompilers.indexOf(comp.brunchPluginName) !== -1 || comp.brunchPluginName === 'javascript-brunch';
+      });
+    }
+
+    return readFromCache(path).then(null, err => Promise.reject(prepareError('Read', err)))
+      .then(source => {
+        if (selectedCompilers.length) {
+          return processJob(CompileJob, {path, source, linters: selectedLinters, compilers: selectedCompilers});
+        } else {
+          return {compiled: source, source, path};
+        }
+      }).then(file => {
+        return deppack.wrapSourceInModule(file.compiled, _path).then(compiled => {
+          file.compiled = compiled;
+          return file;
+        });
+      }).then(file => {
+        return {compiled: file.compiled, source: file.source, path: path};
+      }
+      ).then(deppack.exploreDeps(fileList));
   } else {
     return readFromCache(path).then(path => {
       return Promise.resolve(path);

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -103,10 +103,10 @@ const makeWrapper = (wrapper, path, isWrapped, isntModule) => {
   return node => isWrapped ? wrapper(path, node, isntModule) : node;
 };
 
-const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap) => {
+const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap, depCompilers) => {
   const normalizedPath = replaceBackSlashes(path);
   return () => {
-    return pipeline(normalizedPath, linters, compilers, cache.fileList)
+    return pipeline(normalizedPath, linters, compilers, cache.fileList, depCompilers)
       .then(data => {
         return updateCache(normalizedPath, cache, null, data, wrap, jsWrap).then(() => null);
       }, error => {
@@ -117,7 +117,7 @@ const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap) => {
 
 // A file that will be compiled by brunch.
 class SourceFile {
-  constructor(path, compilers, linters, wrapper, isHelper, isVendor, fileList) {
+  constructor(path, compilers, linters, wrapper, isHelper, isVendor, fileList, depCompilers) {
     this.fileList = fileList;
     // treat json files from node_modules as javascript
     const first = compilers && compilers[0];
@@ -138,7 +138,7 @@ class SourceFile {
     this.isModule = !isntModule;
     this.removed = false;
     this.disposed = false;
-    this.compile = makeCompiler(path, this, linters, compilers, wrap, jsWrap);
+    this.compile = makeCompiler(path, this, linters, compilers, wrap, jsWrap, depCompilers);
     debug(`Init ${path}: %s`, prettify({isntModule, isWrapped}));
 
     Object.seal(this); // Disallow adding new properties.


### PR DESCRIPTION
See GH-1300

This allows to compile ES6 npm modules with babel.

The limitation is that for the time being only `.js` files are supported, as support of other extensions will probably require some more changes to deppack. Non-JS files are clearly not a priority so this should be ok. Eventually we will allow other extensions from npm packages. 

(GH-1309 ping @jahbini)

Related PRs:

- https://github.com/brunch/deppack/pull/24
- https://github.com/babel/babel-brunch/pull/30 

@paulmillr:

- [x] merge deppack & release https://github.com/brunch/deppack/pull/24
- [x] merge babel-brunch 
- [x] Readme updates for babel-brunch and other places
- [x] release https://github.com/babel/babel-brunch/pull/30
- [ ] merge this
- [ ] bump deppack
- [ ] release