### PR TITLE
Failing test with config override regression

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const test = require('ava');
+const config = require('../lib/config');
+
+test('loads the config without overriding', t => {
+  const opts = {
+    config: path.relative(__dirname, './fixtures/config-with-overrides.js')
+  };
+
+  return config.loadConfig(false, opts, true).then((config) => {
+    t.is(config.paths.public, 'public');
+    t.deepEqual(config.paths.watched, ['app', 'test']);
+  });
+});
+
+test('overrides the config using the specified env', t => {
+  const opts = {
+    env: 'test',
+    config: path.relative(__dirname, './fixtures/config-with-overrides.js')
+  };
+
+  return config.loadConfig(false, opts, true).then((config) => {
+    t.is(config.paths.public, 'tmp');
+    t.deepEqual(config.paths.watched, ['app', 'test']);
+  });
+});

--- a/test/fixtures/config-with-overrides.js
+++ b/test/fixtures/config-with-overrides.js
@@ -1,0 +1,13 @@
+module.exports = {
+  overrides: {
+    test: {
+      paths: {
+        public: 'tmp'
+      }
+    }
+  },
+  files: {},
+  paths: {
+    watched: ['app', 'test']
+  }
+};


### PR DESCRIPTION
Since 2.7.2, looks like brunch is not correctly merging some values when using the env option. I created a failing test case to illustrate this issue.

In the second test: `overrides the config using the specified env` the expected value for `config.paths.watched` is `['app', 'test']` but instead it returns `['app', 'test', 'vendor']`. In 2.7.1 this test pass.