### PR TITLE
An attempt to fix #1320

### DIFF
--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -96,7 +96,7 @@ class FileList extends EventEmitter {
   resetTimer() {
     if (this.timer) clearTimeout(this.timer);
     this.timer = setTimeout(() => {
-      this.files.forEach((file, p) => file.disposed && this.files.delete(p));
+      this.removeDisposedFiles();
       if (this.hasPendingFiles()) {
         this.resetTimer();
       } else {
@@ -105,7 +105,11 @@ class FileList extends EventEmitter {
       }
     }, this.resetTime);
   }
-
+  
+  removeDisposedFiles() {
+    this.files.forEach((file, p) => file.disposed && this.files.delete(p));
+  }
+  
   find(path) {
     path = normalizePath(path);
     return this.files.get(path);

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -105,11 +105,11 @@ class FileList extends EventEmitter {
       }
     }, this.resetTime);
   }
-  
+
   removeDisposedFiles() {
     this.files.forEach((file, p) => file.disposed && this.files.delete(p));
   }
-  
+
   find(path) {
     path = normalizePath(path);
     return this.files.get(path);

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -145,8 +145,8 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
         disposed.sourcePaths.push(sysPath.basename(file.path));
         file.dispose();
       });
-      
-    generated.targets = generated.targets.filter(x => !x.file.disposed);      
+
+    generated.targets = generated.targets.filter(x => !x.file.disposed);
   });
 
   return Promise.all(changed.map(file => {

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -143,13 +143,12 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
       .forEach(file => {
         disposed.generated.push(generated);
         disposed.sourcePaths.push(sysPath.basename(file.path));
-        sourceFiles.splice(sourceFiles.indexOf(file), 1);
         file.dispose();
       });
   });
 
   return Promise.all(changed.map(file => {
-    return generate(file.path, file.targets, config, optimizers);
+    return generate(file.path, file.targets.filter(x => !x.file.disposed), config, optimizers);
   })).then(() => Promise.resolve({changed, disposed}));
 };
 

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -145,10 +145,12 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
         disposed.sourcePaths.push(sysPath.basename(file.path));
         file.dispose();
       });
+      
+    generated.targets = generated.targets.filter(x => !x.file.disposed);      
   });
 
   return Promise.all(changed.map(file => {
-    return generate(file.path, file.targets.filter(x => !x.file.disposed), config, optimizers);
+    return generate(file.path, file.targets, config, optimizers);
   })).then(() => Promise.resolve({changed, disposed}));
 };
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -289,6 +289,7 @@ class BrunchWatcher {
     }).then(data => {
       const generatedFiles = data.changed;
       const disposed = data.disposed;
+      fileList.removeDisposedFiles();
       fileList.emit('bundled');
       logger.info(helpers.generateCompilationLog(
         startTime, fileList.assets, generatedFiles, disposed


### PR DESCRIPTION
https://github.com/brunch/brunch/issues/1320
I debugged that problem a bit more and also reviewed the history of related files.

Important milestones: 
1. https://github.com/brunch/brunch/commit/3b3d417266863debc7a612c3daf3955d3881ddcd
2. https://github.com/brunch/brunch/commit/62bc90106771d90768b02014317158cf64519678#diff-50761161d23ef09d8be139f4da670154

The changes:
1. `write.js`. I removed the `splice` call, since as I understand in the first commit listed above it was intended to prevent calling `generate` on removed files. After the second change I listed it isn't doing any useful work as I see. I also filtered removed files from `targets`, as it was in the initial version.
2. `watch.js`. I called `removeDisposedFiles`. I did that, because the file related to the removed dependency is still present in the list after 'unliking', but has `disposed=true` and `removed=true`. When the dependency will be added back, it will be ignored due to the check in `explore.js`, line 110: `if (!fileList.find(p))`.

For me it fixed the problem, but I'm not sure if it is the best solution, because the code base is completely new for me. Let's check and discuss it.