### PR TITLE
Try to recover from MODULE_NOT_FOUND in the config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -625,6 +625,14 @@ module.exports = {
 const tryToLoad = (configPath, fallbackHandler) => {
   let fullPath;
   let basename = configPath;
+
+  let pkg;
+
+  try {
+    pkg = require(sysPath.resolve('.', 'package.json'));
+  } catch (e) {
+  }
+
   return new Promise((resolve, reject) => {
     debug(`Trying to load ${configPath}`);
     let resolved;
@@ -664,6 +672,17 @@ const tryToLoad = (configPath, fallbackHandler) => {
       }
 
       fallbackHandler();
+    } else if (pkg && error.code === 'MODULE_NOT_FOUND') {
+      const modRe = /Cannot find module '([\w\d-\/]+)'/;
+      const mod = modRe.exec(error.toString())[1];
+      if (mod && mod[0] !== '.') {
+        const topLevelMod = mod.split('/')[0];
+        const pkgs = Object.assign({}, pkg.dependencies || {}, pkg.devDependencies || {});
+        if (topLevelMod in pkgs) {
+          logger.warn(`Config requires '${topLevelMod}' which is in package.json but wasn't yet installed. Trying to install...`);
+          return exports.install('.', 'npm').then(() => tryToLoad(configPath));
+        }
+      }
     }
     error.code = 'BRSYNTAX';
     error.message = 'Failed to load brunch config - ' + error.message;


### PR DESCRIPTION
If the package being required is in package.json but still can't be
loaded, that's a sign that an npm install is due, which this commit
introduces.

Note however that it does assume '.' as the root path, but given that
config's root can't be any place else, it should be ok.