### PR TITLE
Fix a regression introduced by e80299

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -434,7 +434,7 @@ const createJoinConfig = (configFiles, paths) => {
 
 const setConfigDefaults = exports.setConfigDefaults = (config, configPath) => {
   const join = (parent, name) => {
-    return sysPath.resolve(config.paths[parent], name);
+    return sysPath.isAbsolute(name) ? name : sysPath.join(config.paths[parent], name);
   };
   const joinRoot = name => {
     return join('root', name);


### PR DESCRIPTION
In general, paths should not be made absolute unless an absolute pass
was explicitly passed.