### PR TITLE
Normalize paths to always use UNIX slashes internally

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 'use strict';
 const fs = require('fs');
-const sysPath = require('path');
+const sysPath = require('./path');
 const exec = require('child_process').exec;
 const logger = require('loggy');
 const readComponents = require('read-components');
@@ -14,10 +14,6 @@ const loadInit = deppack.loadInit;
 const mdls = require('./modules');
 
 const skemata = require('skemata');
-
-const _helpers = require('./helpers');
-const isWindows = _helpers.isWindows;
-const replaceSlashes = _helpers.replaceSlashes;
 
 coffee.register();
 
@@ -276,47 +272,6 @@ exports.install = (rootPath, command, isProduction) => {
   });
 };
 
-const replaceConfigSlashes = exports.replaceConfigSlashes = config => {
-  if (!isWindows) return config;
-
-  const slashifyJoinTo = joinTo => {
-    switch (toString.call(joinTo)) {
-      case '[object String]':
-        return replaceSlashes(joinTo);
-      case '[object Object]':
-        return Object.keys(joinTo).reduce((newJoinTo, joinToKey) => {
-          newJoinTo[replaceSlashes(joinToKey)] = joinTo[joinToKey];
-          return newJoinTo;
-        }, {});
-    }
-  };
-
-  const files = config.files || {};
-  Object.keys(files).forEach(language => {
-    const lang = files[language] || {};
-    const order = lang.order || {};
-
-    // Modify order.
-    Object.keys(order).forEach(orderKey => {
-      return lang.order[orderKey] = lang.order[orderKey].map(replaceSlashes);
-    });
-
-    Object.keys(lang.entryPoints || {}).forEach(entry => {
-      const val = lang.entryPoints[entry];
-      const newEntry = replaceSlashes(entry);
-      const newVal = slashifyJoinTo(val);
-
-      delete lang.entryPoints[entry];
-      lang.entryPoints[newEntry] = newVal;
-    });
-
-    // Modify join configuration.
-    lang.joinTo = slashifyJoinTo(lang.joinTo);
-  });
-  return config;
-};
-
-
 // Config items can be a RegExp or a function.  The function makes universal API to them.
 // Takes RegExp or Function
 // Returns Function.
@@ -402,8 +357,7 @@ const createJoinConfig = (configFiles, paths) => {
       }
 
       Object.keys(fileCfg.entryPoints).forEach(target => {
-        const slashes = x => x.split(sysPath.sep).join('/');
-        const isTargetWatched = paths.watched.some(path => slashes(target).indexOf(slashes(path) + '/') === 0);
+        const isTargetWatched = paths.watched.some(path => target.indexOf(path + '/') === 0);
         if (!isTargetWatched) {
           logger.warn(`The correct use of entry points is: \`'entryFile.js': 'outputFile.js'\`. You are trying to use '${target}' as an entry point, but it is probably an output file.`);
         }
@@ -702,7 +656,6 @@ exports.loadConfig = (persistent, opts, fromWorker) => {
     .then(fromWorker ? noop : addDefaultServer)
     .then(config => applyOverrides(config, options))
     .then(config => deepAssign(config, options))
-    .then(replaceConfigSlashes)
     .then(normalizeConfig)
     .then(fromWorker ? noop : addPackageManagers)
     .then(deepFreeze);

--- a/lib/fs_utils/asset.js
+++ b/lib/fs_utils/asset.js
@@ -1,6 +1,6 @@
 'use strict';
 const debug = require('debug')('brunch:asset');
-const sysPath = require('path');
+const sysPath = require('../path');
 const copyFile = require('quickly-copy-file');
 const prettify = require('../helpers').prettify;
 const isIgnored = require('./common').isIgnored;
@@ -13,7 +13,7 @@ const isIgnored = require('./common').isIgnored;
 // Returns String.
 const getAssetDirectory = (path, convention) => {
   const sep = sysPath.sep;
-  const split = path.split(sep);
+  const split = path.split('/');
 
   // Creates thing like this
   // ['app/', 'app/assets/', 'app/assets/thing/', 'app/assets/thing/item.html/']
@@ -45,6 +45,7 @@ class Asset {
   copy() {
     const path = this.path;
     if (isIgnored(path)) return Promise.resolve();
+    console.log(path, this.destPath);
     return copyFile(path, this.destPath).then(() => {
       debug(`Copied ${path}`);
       this.updateTime();

--- a/lib/fs_utils/common.js
+++ b/lib/fs_utils/common.js
@@ -1,5 +1,5 @@
 'use strict';
-const basename = require('path').basename;
+const basename = require('../path').basename;
 
 // Common helpers for file system.
 

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -1,8 +1,8 @@
 'use strict';
-const separator = require('path').sep;
+const sysPath = require('../path');
 const debug = require('debug')('brunch:list');
 const EventEmitter = require('events').EventEmitter;
-const normalize = require('path').normalize;
+const normalize = require('../path').normalize;
 const readFileAndCache = require('fcache').updateCache;
 const deppack = require('deppack'); // isNpmJSON, isNpm
 const formatError = require('../helpers').formatError;
@@ -13,7 +13,7 @@ const startsWith = (string, substring) => {
   return string.lastIndexOf(substring, 0) === 0;
 };
 
-const normalizePath = (path) => path.split('/').join(separator);
+const normalizePath = (path) => sysPath.slashes(path);
 
 // File list.
 // A list of SourceFiles that contains *all* files from Brunches app.

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -1,6 +1,6 @@
 'use strict';
 const debug = require('debug')('brunch:generate');
-const sysPath = require('path');
+const sysPath = require('../path');
 const anysort = require('anysort');
 const promisify = require('micro-promisify');
 const fsWriteFile = promisify(require('fs').writeFile);
@@ -71,8 +71,6 @@ const sort = (files, config, joinToValue) => {
 
 
 // New.
-const slashes = string => string.replace('\\', '/');
-
 const semi = ';';
 const concat = (files, path, definitionFn, autoRequire, config) => {
   if (autoRequire == null) autoRequire = [];
@@ -91,7 +89,7 @@ const concat = (files, path, definitionFn, autoRequire, config) => {
   };
 
   if (isJs) {
-    const addRequire = req => root.add(`require('${slashes(req)}');`);
+    const addRequire = req => root.add(`require('${req}');`);
 
     const isNpm = config.npm.enabled ? deppack.needsProcessing : () => false;
     const isHmr = isHmrEnabled(config);
@@ -217,7 +215,7 @@ const generate = (path, targets, config, optimizers) => {
   const definition = type === 'javascript' ? norm.modules.definition : null;
   const cc = concat(
     sorted, path, definition,
-    norm.modules.autoRequire[slashes(joinKey)],
+    norm.modules.autoRequire[joinKey],
     config
   );
   const code = cc.code;
@@ -228,7 +226,7 @@ const generate = (path, targets, config, optimizers) => {
     .then(data => {
       if (withMaps) {
         const mapRoute = config.sourceMaps === 'absoluteUrl' ?
-          slashes(mapPath.replace(config.paths['public'], '')) :
+          mapPath.replace(config.paths['public'], '') :
           sysPath.basename(mapPath);
         const controlChar = config.sourceMaps === 'old' ? '@' : '#';
         const end = `${controlChar} sourceMappingURL=${mapRoute}`;

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -1,5 +1,5 @@
 'use strict';
-const sysPath = require('path');
+const sysPath = require('../path');
 const logger = require('loggy');
 const debug = require('debug')('brunch:pipeline');
 const promisify = require('micro-promisify');

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -12,8 +12,6 @@ const pipeline = require('./pipeline').pipeline;
 const _helpers = require('../helpers'); // below
 const prettify = _helpers.prettify;
 const identityNode = _helpers.identityNode;
-const replaceBackSlashes = _helpers.replaceBackSlashes;
-const isWindows = _helpers.isWindows;
 
 // SourceFile: (data) -> File
 // Abstraction on top of source file (that's read / compiled.)
@@ -23,9 +21,6 @@ const sMapRe = /^\)\]\}'/;
 const prepareSourceMap = (sourceMap, wrapperContent) => {
   const mapping = typeof sourceMap === 'string' ?
     JSON.parse(sourceMap.replace(sMapRe, '')) : sourceMap;
-  if (isWindows && mapping.sources) {
-    mapping.sources = mapping.sources.map(replaceBackSlashes);
-  }
   const map = new SourceMapConsumer(mapping);
   return SourceNode.fromStringWithSourceMap(wrapperContent, map);
 };
@@ -104,7 +99,7 @@ const makeWrapper = (wrapper, path, isWrapped, isntModule) => {
 };
 
 const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap, depCompilers) => {
-  const normalizedPath = replaceBackSlashes(path);
+  const normalizedPath = path;
   return () => {
     return pipeline(normalizedPath, linters, compilers, cache.fileList, depCompilers)
       .then(data => {

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -1,6 +1,6 @@
 'use strict';
 const debug = require('debug')('brunch:write');
-const sysPath = require('path');
+const sysPath = require('../path');
 const logger = require('loggy');
 
 const deppack = require('deppack'); // getAllDependents

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,21 +1,14 @@
 'use strict';
-const getBasename = require('path').basename;
+const getBasename = require('./path').basename;
 const SourceNode = require('source-map').SourceNode;
 const promisify = require('micro-promisify');
 
 exports.isWindows = require('os').platform() === 'win32';
 
-const windowsStringReplace = (search, replacement) => {
-  return str => (exports.isWindows && typeof str === 'string') ?
-    str.replace(search, replacement) : str;
-};
-
 // Single-level flatten.
 exports.flatten = (array) => [].concat.apply([], array);
 
 exports.promisifyPlugin = (arity, fn) => fn.length === arity ? fn : promisify(fn);
-exports.replaceSlashes = windowsStringReplace(/\//g, '\\');
-exports.replaceBackSlashes = windowsStringReplace(/\\/g, '\/');
 
 exports.asyncFilter = (arr, fn) => {
   const promises = arr.map(item => fn(item).then(result => [item, result]));

--- a/lib/hmr.js
+++ b/lib/hmr.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const sysPath = require('path');
+const sysPath = require('./path');
 const logger = require('loggy');
 
 const isEnabled = config => config.hot && config.env.indexOf('production') === -1;

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,0 +1,23 @@
+'use strict';
+const sysPath = require('path');
+
+const isAbsolute = sysPath.isAbsolute;
+const basename = sysPath.basename;
+const sep = sysPath.sep;
+
+const slashes = x => x.split('\\').join('/');
+const unslashes = x => x.split('/').join(sep);
+
+const _wrap = fn => {
+  return function() {
+    return slashes(fn.apply(sysPath, arguments));
+  };
+};
+
+const normalize = _wrap(sysPath.normalize);
+const relative = _wrap(sysPath.relative);
+const resolve = _wrap(sysPath.resolve);
+const join = _wrap(sysPath.join);
+const dirname = _wrap(sysPath.dirname);
+
+module.exports = {basename, dirname, sep, isAbsolute, slashes, unslashes, relative, join, resolve, normalize};

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,5 +1,5 @@
 'use strict';
-const sysPath = require('path');
+const sysPath = require('./path');
 const debug = require('debug')('brunch:plugins');
 const logger = require('loggy');
 const speed = require('since-app-start');

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,5 @@
 'use strict';
-const sysPath = require('path');
+const sysPath = require('./path');
 const getRelativePath = sysPath.relative;
 const logger = require('loggy');
 const chokidar = require('chokidar');
@@ -200,12 +200,14 @@ class BrunchWatcher {
     })
       .on('error', logger.error)
       .on('add', absPath => {
+        absPath = sysPath.slashes(absPath);
         if (isDebug) debug(`add ${absPath}`);
         const path = getRelativePath(rootPath, absPath);
         if (isConfig(path)) return; // Pass for the initial files.
         this.startCompilation(path);
       })
       .on('change', absPath => {
+        absPath = sysPath.slashes(absPath);
         if (isDebug) debug(`change ${absPath}`);
         const path = getRelativePath(rootPath, absPath);
         if (possibleConfigFiles[path] || path === packageConfig) {
@@ -217,6 +219,7 @@ class BrunchWatcher {
         }
       })
       .on('unlink', absPath => {
+        absPath = sysPath.slashes(absPath);
         if (isDebug) debug(`unlink ${absPath}`);
         const path = getRelativePath(rootPath, absPath);
         if (isConfig(path)) return this.exitProcessFromFile(path);
@@ -263,6 +266,7 @@ class BrunchWatcher {
    * Returns nothing.
    */
   changeFileList(path, isHelper) {
+    path = sysPath.slashes(path);
     const compiler = this.plugins.compilers.filter(plugins.isPluginFor(path));
     const currentLinters = this.plugins.linters.filter(plugins.isPluginFor(path));
     this.fileList.emit('change', path, compiler, currentLinters, isHelper);


### PR DESCRIPTION
Ref GH-1281

Allows to get rid of platform-specific path handling in config regexps,
et cetera, and also relieves plugins from having to care about that.

Filesystem access functions work just fine with the `/`s.

Paths consistency is acheieved by normalizing the paths that come from
the watcher and by providing a local drop-in replacement for the `path`
module which always returns paths with the `/`s.

---

Deppack PR: https://github.com/brunch/deppack/pull/30

@paulmillr to do:

- [x] merge https://github.com/brunch/deppack/pull/30
- [x] release deppack **0.5.0**
- [x] bump deppack to **0.5.0**
- [ ] merge this