### PR TITLE
Implement API for static compiler plugins

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -74,6 +74,9 @@ paths: {
         * after: [anymatch set](https://github.com/es128/anymatch#anymatch-) defining files that will be loaded after other files
     * pluginHelpers: (optional) specify which output file (or array of files) plugins' include files concatenate into. Defaults to the output file that `vendor` files are being joined to, the first one with `vendor` in its name/path, or just the first output file listed in your joinTo object.
 
+* `statics` is a special case. It is used to configre static file compilation. The only option is:
+    * rootPath: a path that static files will be relative to. Defaults to `app`. For example, `rootPath = 'app'` will qualify `app/about.jade` as `about.jade`, writing it into `public/about.html`; if `rootPath = '.'`, then it would have been written into `public/app/about.jade`.
+
 All files from `vendor` directory are by default concatenated before all files from `app` directory. So, `vendor/scripts/jquery.js` would be loaded before `app/script.js` even if order config is empty. Files from Bower packages are included by default before the `vendor` files.
 
 Overall ordering is [before] -> [bower] -> [vendor] -> [everything else] -> [after]

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -229,6 +229,35 @@ class MyCompiler {
 
 Note: exported JS will not be compiled or linter by any other plugin and its `require` statements will not be resolved. Make sure your exported JS is self-contained.
 
+### Static file compilers
+
+Sometimes, you would want to process different kinds of files, to which the Brunch's general compile-join-write logic does not apply.
+Jade templates to HTML is one example.
+You want to have a `.jade` file compiled into `.html`.
+Previously, what you would do in this case was to hook into `onCompile` and look for jade files... and then compile them and write them manually. Sucks.
+
+So starting Brunch `<unreleased>`, there is a better way.
+
+```javascript
+class StaticJadeCompilerNew {
+  compile(params) {
+    const path = params.path;
+    const data = params.data;
+
+    return new Promise((resolve, reject) => {
+      toHtml(path, data, (err, data) => {
+        if (err) return reject(err);
+        resolve(data);
+      });
+    });
+  }
+}
+StaticJadeCompilerNew.prototype.brunchPlugin = true;
+StaticJadeCompilerNew.prototype.type = 'static';
+StaticJadeCompilerNew.prototype.extension = "jade";
+StaticJadeCompilerNew.prototype.targetExtension = "html";
+```
+
 ## Publishing
 
 Making your plugin available to everyone is as simple as

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,6 +47,11 @@ const configBaseSchema = v.object({
       if (['app', 'test', 'vendor', 'assets'].indexOf(key) !== -1) {
         return 'was removed, use `config.paths.watched` instead';
       }
+    },
+    specifics: {
+      statics: v.object({
+        rootPath: v.string.default('app')
+      }).default({})
     }
   }, v.object({
     joinTo: v.either(

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -247,6 +247,15 @@ const generate = (path, targets, config, optimizers) => {
     });
 };
 
+generate.writeStatics = (files) => {
+  const promises = files.map(x => {
+    const file = x.file;
+    const targetPath = x.targetPath;
+    return writeFile(targetPath, file.targets.static.data);
+  });
+  return Promise.all(promises);
+};
+
 generate.sortByConfig = sortByConfig;
 generate.OptimizeJob = OptimizeJob;
 

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -134,6 +134,14 @@ class SourceFile {
     this.removed = false;
     this.disposed = false;
     this.compile = makeCompiler(path, this, linters, compilers, wrap, jsWrap, depCompilers);
+
+    if (type === 'static') {
+      const staticComp = compilers[0];
+      this.sourceExt = staticComp.extension;
+      this.sourcePattern = staticComp.pattern;
+      this.targetExtension = staticComp.targetExtension;
+    }
+
     debug(`Init ${path}: %s`, prettify({isntModule, isWrapped}));
 
     Object.seal(this); // Disallow adding new properties.

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -107,6 +107,7 @@ const checkWritten = (fileList, files, startTime) => {
     if (file.error) logger.error(formatWriteError(file));
     if (file.compilationTime >= startTime) {
       Object.keys(file.targets).forEach(type => {
+        if (type === 'static') return;
         const target = file.targets[type];
         const allTargets = allWrittenTargets[type] || [];
         if (allTargets.indexOf(file.path) === -1 && target.data) {
@@ -118,7 +119,31 @@ const checkWritten = (fileList, files, startTime) => {
   });
 };
 
-const write = (fileList, config, joinConfig, optimizers, startTime) => {
+const writeStatics = (fileList, config, startTime) => {
+  const allFiles = Array.from(fileList.files.values());
+  const statics = allFiles.filter(f => f.type === 'static' && f.compilationTime >= startTime);
+  const errors = statics.filter(x => x.error).map(formatWriteError);
+  errors.forEach(error => logger.error(error));
+
+  const validStatics = statics.map(stat => {
+    if (stat.error) return;
+    const relPath = sysPath.relative(config.files.statics.rootPath, stat.path);
+    if (relPath.slice(0, 2) === '..') {
+      logger.warn(`Resolved ${stat.path} as ${relPath}, skipping. Relative path of a static file should never start with '..'. Possible fix: change 'config.files.statics.rootPath'.`);
+      return;
+    }
+    const extRe = stat.sourcePattern ? stat.sourcePattern : new RegExp(`\\.${stat.sourceExt}$`);
+    const relWithExt = relPath.replace(extRe, '.' + stat.targetExtension);
+    const targetPath = sysPath.join(config.paths.public, relWithExt);
+    return { file: stat, targetPath };
+  }).filter(x => x);
+
+  debug(`Writing ${validStatics.length} static files`);
+
+  return generate.writeStatics(validStatics);
+};
+
+const writeJoins = (fileList, config, joinConfig, optimizers, startTime) => {
   const files = getFiles(fileList, config, joinConfig);
   checkWritten(fileList, files, startTime);
   const errors = files
@@ -152,6 +177,12 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
   return Promise.all(changed.map(file => {
     return generate(file.path, file.targets, config, optimizers);
   })).then(() => Promise.resolve({changed, disposed}));
+};
+
+const write = (fileList, config, joinConfig, optimizers, startTime) => {
+  const statics = writeStatics(fileList, config, startTime);
+  const joins = writeJoins(fileList, config, joinConfig, optimizers, startTime);
+  return statics.then(() => joins);
 };
 
 module.exports = write;


### PR DESCRIPTION
Allows to implement plugins like static-jade-brunch much simpler, by
introducing another type of compilers — static compilers. They are
distinct from js/css/template compilers in a few regards:

- first and foremost, there is no 'joining' step for static file — they
  are written directly. Each source file corresponds to one compiled
  file
- allows to handle any plain-text static file. The plugin dictates the
  resulting file extension. (But not binary files. In practice, it means
  there can be an svgo compiler that both takes and produces svg.
  Doesn't apply to png, jpg, and other binary formats though)

A side benefit of this first-class support is that there are no two
successive change events with almost no delay, which was causing an
issue with autoreload sometimes (GH-1268)