### PR TITLE
Make watcher restarts clean

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -5,6 +5,7 @@ global.appStartTime = Date.now();
 
 var sysPath = require('path');
 var fs = require('fs');
+var childProcess = require('child_process');
 var version = process.version;
 var verDigit = parseInt(version.match(/^v(\d+)\./)[1]);
 
@@ -16,33 +17,71 @@ if (verDigit < 4) {
 }
 
 var cwd = sysPath.resolve('.');
-var cliFile = sysPath.join('lib', 'cli.js');
+var cliFile = sysPath.join('lib', 'run-cli.js');
+// for compatibility with Brunch 2.7.7 and lower
+var cliOldFile = sysPath.join('lib', 'cli.js');
 var localPath = sysPath.join(cwd, 'node_modules', 'brunch', cliFile);
+var localOldPath = sysPath.join(cwd, 'node_modules', 'brunch', cliOldFile);
 
-var loadBrunch = function(path) {
-  var cli = require(path);
+var loadBrunch = function(path, oldPath) {
+  // this approach is only needed for watch command
+  if (path && process.argv[2] === 'w' || process.argv[2] === 'watch') {
+    try {
+      // this will spawn the watcher in a child process
+      // we needed it to handle brunch watcher restarts cleanly
+      // by killing the child process and starting it again
+      //
+      // the previous approach was to not reload the process but
+      // to simply to to clean require.cache - but it was not reliable
+      // and caused memory leaks
+      var proc = childProcess.fork(path, process.argv.slice(2));
+      proc.on('message', function(msg) {
+        if (msg === 'reload') {
+          proc.kill();
+          loadBrunch(path);
+        }
+      });
+      return;
+    } catch (e) {
+      // no op, proceed to the old approach (if the command wasn't `watch` or if local brunch version does not support forking)
+    }
+  }
+
+  // this is needed to support cases when the local brunch is of an older version
+  // and does not have a run-cli.js file
+  var cli = require(oldPath);
   cli.run();
 };
 
 var loadGlobalBrunch = function() {
   fs.realpath(__dirname, function(err, real) {
     if (err) throw err;
-    loadBrunch(sysPath.join(real, '..', cliFile));
+    loadBrunch(sysPath.join(real, '..', cliFile), sysPath.join(real, '..', cliOldFile));
   });
+};
+
+var tryLoadBrunch = function(path, oldPath) {
+  try {
+    loadBrunch(path, oldPath);
+  } catch(error) {
+    console.error(
+      'Brunch: Local install exists, but failed to load it. ' +
+      'Continuing with global install:', error
+    );
+    loadGlobalBrunch();
+  }
 };
 
 fs.access(localPath, function(error) {
   if (error) {
-    loadGlobalBrunch();
+    fs.access(localOldPath, function(error) {
+      if (error) {
+        loadGlobalBrunch();
+      } else {
+        tryLoadBrunch(null, localOldPath);
+      }
+    });
   } else {
-    try {
-      loadBrunch(localPath);
-    } catch(error) {
-      console.error(
-        'Brunch: Local install exists, but failed to load it. ' +
-        'Continuing with global install:', error
-      );
-      loadGlobalBrunch();
-    }
+    tryLoadBrunch(localPath, localOldPath);
   }
 });

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -78,6 +78,10 @@ const checkForRemovedOptions = (args, command) => {
 exports.run = () => {
   const args = process.argv.slice();
 
+  // Need this since `brunch` binary will fork and run `run-cli`,
+  // but we still want to see `brunch` in help.
+  args[1] = 'brunch';
+
   // Check if it's alias.
   const command = args[2];
   const validCommand = aliases[command];

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -40,16 +40,6 @@ const getPluginIncludes = plugins => {
   .reduce((acc, elem) => { return acc.concat(ensureArray(elem)); }, []);
 };
 
-const cleanChildren = (mod) => {
-  mod.children.forEach(cleanChildren);
-  delete require.cache[mod.id];
-};
-
-const recursivelyResetModuleCache = depPath => {
-  const id = require.resolve(depPath);
-  if (id && id in require.cache) cleanChildren(require.cache[id]);
-};
-
 const requireModule = (depPath, dependencyName) => {
   const plugin = require(depPath);
   speed.profile('Loaded plugin ' + dependencyName);
@@ -80,7 +70,6 @@ const loadPackages = (rootPath) => {
       const depPath = nodeModules + '/' + dependency;
       if (isDev) {
         try {
-          recursivelyResetModuleCache(depPath);
           return requireModule(depPath, dependency, true);
         } catch (error) {
           return null;

--- a/lib/run-cli.js
+++ b/lib/run-cli.js
@@ -1,0 +1,3 @@
+'use strict';
+const cli = require('./cli');
+cli.run();

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -241,8 +241,14 @@ class BrunchWatcher {
       this.fileList.dispose();
       this.watcher.close();
       workers.close();
-      const opts = this._constructorOptions;
-      return new BrunchWatcher(opts[0], opts[1], opts[2]);
+      // we need this to keep compatibility with global `brunch` binaries
+      // from older versions which didn't create a child process
+      if (process.send) {
+        process.send('reload');
+      } else {
+        const opts = this._constructorOptions;
+        return new BrunchWatcher(opts[0], opts[1], opts[2]);
+      }
     };
 
     const reWatch = () => {


### PR DESCRIPTION
This allows to cleanly restart the watcher. The previous approach with
manually trying to clean require.cache didn't work well and produced
various memory leaks.

This commit changes the brunch init process: the binary does not
directly run brunch commands, but instead, creates a child process that
processed the commands. In case the child process needs to restart, it
kills it and runs another one.

It works properly under two conditions: both global brunch binary and
the local brunch installation contain this commit. If the global brunch
is older, or if the local brunch is older, the old behavior will be
preserved.

---

Note: what this means is there will be at least two processes when running `brunch watch` (but not other commands) — one that handles restarts, another that does the actual processing. However, the overhead of this approach should not be significant since the binary process does not actively do anything but wait for the `restart` message from the watcher. Its memory footprint should also be minimal since it only requires system modules.