### PR TITLE
Add tests for npm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
+os:
+  - linux
+  - osx
 node_js:
   - '6'
   - '5'


### PR DESCRIPTION
Too bad Travis doesn't do windows yet, having all builds also run Windows would have allowed us to catch Windows-only bugs early (now that we are normalizing paths to `/` this kind of an issue should be a rarity though)

Testing wise, the next steps could well be:

* setting expectations not only for `public` files content, but also for brunch output (errors, warnings, etc)
* then, roll out a headless webkit setup to allow to run the generated javascript and see if it executes without any errors (this will allow to catch a certain set of runtime issues, like the commonjs runtime)