### PR TITLE
Fix brunch global bin path

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -53,7 +53,7 @@ var loadBrunch = function(libPath) {
 };
 
 var loadGlobalBrunch = function() {
-  loadBrunch(join(fs.realpathSync(__dirname), '..'));
+  loadBrunch(join(fs.realpathSync(__dirname), '..', 'lib'));
 };
 
 var localPath = join(sysPath.resolve('.'), 'node_modules', 'brunch', 'lib', files.old);


### PR DESCRIPTION
When using brunch from the master branch, and linking with `npm link` I receive the following error in a project without a local brunch dependency:

```
module.js:341
    throw err;
    ^

Error: Cannot find module '/home/marcio/workspace/javascript/brunch/cli.js'
    at Function.Module._resolveFilename (module.js:339:15)
    at Function.Module._load (module.js:290:25)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at loadBrunch (/home/marcio/workspace/javascript/brunch/bin/brunch:52:3)
    at loadGlobalBrunch (/home/marcio/workspace/javascript/brunch/bin/brunch:56:3)
    at Object.<anonymous> (/home/marcio/workspace/javascript/brunch/bin/brunch:71:3)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
```

With this patch it works correctly. I believe the `lib` directory is missing in this path.