### PR TITLE
Fix BRUNCH_FORKED_PROCESS global variable

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -29,7 +29,7 @@ var exists = function(path) {
 };
 
 var runSeparateWatchProcess = function(cliPath) {
-  process.env.BRUNCH_FORKED_PROCESS = true;
+  process.env.BRUNCH_FORKED_PROCESS = 'true';
   var proc = childProcessFork(cliPath, process.argv.slice(2));
   proc.on('message', function(message) {
     if (message === 'reload') {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -245,7 +245,7 @@ class BrunchWatcher {
     const restart = () => {
       // we need this to keep compatibility with global `brunch` binaries
       // from older versions which didn't create a child process
-      if (process.send && process.env.BRUNCH_FORKED_PROCESS === '1') {
+      if (process.send && process.env.BRUNCH_FORKED_PROCESS === 'true') {
         process.send('reload');
       } else {
         const opts = this._constructorOptions;


### PR DESCRIPTION
I added the BRUNCH_FORKED_PROCESS variable in the previous PR but your usage was incorrect, so the reload message will never trigger. Sorry for that.