### PR TITLE
Static compilation new take

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -229,6 +229,45 @@ class MyCompiler {
 
 Note: exported JS will not be compiled or linter by any other plugin and its `require` statements will not be resolved. Make sure your exported JS is self-contained.
 
+### Static file compilers
+
+Sometimes, you would want to process different kinds of files, to which the Brunch's general compile-join-write logic does not apply.
+Jade templates to HTML is one example.
+You want to have a `.jade` file compiled into `.html`.
+Previously, what you would do in this case was to hook into `onCompile` and look for jade files... and then compile them and write them manually. Sucks.
+
+So starting Brunch `<unreleased>`, there is a better way.
+
+```javascript
+class JadeCompiler {
+  compileStatic(params) {
+    const path = params.path;
+    const data = params.data;
+
+    return new Promise((resolve, reject) => {
+      toHtml(path, data, (err, data) => {
+        if (err) return reject(err);
+        resolve(data);
+      });
+    });
+  }
+}
+JadeCompiler.prototype.brunchPlugin = true;
+JadeCompiler.prototype.type = 'template';
+JadeCompiler.prototype.extension = "jade";
+// alternatively, a static extension can be different from `extension`:
+// JadeCompiler.prototype.staticExtension = "static.jade";
+// this is used to tell Brunch which extension to use after static compilation
+JadeCompiler.prototype.staticTargetExtension = 'html';
+```
+
+A plugin can handle both `compile` and `compileStatic`.
+
+Unlike usual compilers, static compilers process files from the assets folder (`app/assets` by default) instead of just copying.
+So, with the example plugin above, `app/assets/index.jade` will be transformed into `public/index.html`.
+
+`getDependencies` will be called for *both* regular files and assets.
+
 ## Publishing
 
 Making your plugin available to everyone is as simple as

--- a/lib/fs_utils/asset.js
+++ b/lib/fs_utils/asset.js
@@ -4,6 +4,9 @@ const sysPath = require('../path');
 const copyFile = require('quickly-copy-file');
 const prettify = require('../helpers').prettify;
 const isIgnored = require('./common').isIgnored;
+const pipeline = require('./pipeline');
+const plugins = require('../plugins');
+const logger = require('loggy');
 
 // Asset: Simple abstraction on top of static assets that are not compiled.
 
@@ -20,6 +23,12 @@ const getAssetDirectory = (path, convention) => {
   return split.map((part, index) => {
     return split.slice(0, index).concat([part, '']).join(sep);
   }).find(convention);
+};
+
+const replaceExt = (rel, compiler) => {
+  const oldRe = plugins.patternFor(compiler, true);
+  const newExt = compiler.staticTargetExtension;
+  return rel.replace(oldRe, '.' + newExt);
 };
 
 
@@ -66,4 +75,56 @@ class Asset {
   }
 }
 
+class CompiledAsset {
+  constructor(path, publicPath, assetsConvention, compiler) {
+    if (compiler.length !== 1) {
+      logger.warn(`Got ${compilers.length} compilers for a static file ${path}, proceeding with the first one: ${compiler[0].brunchPluginName}`);
+    }
+    const directory = getAssetDirectory(path, assetsConvention);
+    const rel = sysPath.relative(directory, path);
+    compiler = compiler[0];
+    const destinationRel = replaceExt(rel, compiler);
+    const destinationPath = sysPath.join(publicPath, destinationRel);
+    const compilerName = compiler.brunchPluginName;
+    this.path = path;
+    this.destinationPath = destinationPath;
+    this.error = null;
+    this.dependencies = [];
+    this.removed = false;
+    this.disposed = false;
+    this.source = '';
+    this.compiled = '';
+    this.compilationTime = null;
+    this._compiler = compiler;
+    debug(`Init ${path} $`, prettify({directory, destinationPath, rel, compilerName}));
+    Object.seal(this);
+  }
+
+  compile() {
+    if (this.disposed) throw new Error(`${this.path} is already disposed`);
+
+    return pipeline.compileStatic(this.path, this._compiler).then(data => {
+      this.source = data.source;
+      this.compiled = data.compiled;
+      this.compilationTime = data.compilationTime;
+      this.dependencies = data.dependencies;
+    }, error => {
+      this.error = error;
+    });
+  }
+
+  dispose() {
+    debug(`Disposing static ${this.path}`);
+    this.path = '';
+    this.dependencies = Object.freeze([]);
+    this.disposed = true;
+    this.error = null;
+    this.source = '';
+    this.compiled = '';
+
+    Object.freeze(this);
+  }
+}
+
 module.exports = Asset;
+module.exports.Static = CompiledAsset;

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -41,6 +41,7 @@ class FileList extends EventEmitter {
     this.depCompilers = config.npm.compilers;
 
     this.files = new Map();
+    this.staticFiles = new Map();
     this.assets = [];
     this.compiling = new Set();
     this.copying = new Set();
@@ -109,6 +110,7 @@ class FileList extends EventEmitter {
 
   removeDisposedFiles() {
     this.files.forEach((file, p) => file.disposed && this.files.delete(p));
+    this.staticFiles.forEach((file, p) => file.disposed && this.staticFiles.delete(p));
   }
 
   find(path) {
@@ -121,11 +123,17 @@ class FileList extends EventEmitter {
     return this.assets.find(file => file.path === path);
   }
 
-  compileDependencyParents(path) {
+  findStatic(path) {
+    path = normalizePath(path);
+    return this.staticFiles.get(path);
+  }
+
+  compileDependencyParents(path, isStatic) {
     path = normalizePath(path);
     const paths = [];
     const parents = [];
-    this.files.forEach((dependent, fpath) => {
+    const files = isStatic ? this.staticFiles : this.files;
+    files.forEach((dependent, fpath) => {
       const deps = dependent.dependencies;
       const isDep = deps && deps.length > 0 &&
         deps.indexOf(path) >= 0 &&
@@ -135,7 +143,7 @@ class FileList extends EventEmitter {
       parents.push(dependent);
     });
     if (!parents.length) return;
-    debug(`Compiling dependency ${path} parent(s): ${paths.join(', ')}`);
+    debug(`Compiling ${isStatic ? 'static ' : ''}dependency ${path} parent(s): ${paths.join(', ')}`);
     parents.forEach(this.compile, this);
   }
 
@@ -190,9 +198,26 @@ class FileList extends EventEmitter {
     return file;
   }
 
+  _addStatic(path, compiler) {
+    try {
+      const file = new Asset.Static(path, this.publicPath, this.conventions.assets, compiler);
+      this.staticFiles.set(file.path, file);
+      return file;
+    } catch (e) {
+      require('loggy').error(e);
+      return;
+    }
+  }
+
   _change(path, compiler, linters, isHelper) {
+    if (this.disposed) { return; }
+
     const ignored = this.isIgnored(path);
-    if (this.is('assets', path)) {
+    const isAsset = this.is('assets', path);
+    const isStatic = isAsset && compiler.length > 0;
+    const isRegularAsset = isAsset && !isStatic;
+
+    if (isRegularAsset) {
       if (!ignored) {
         const file = this.findAsset(path) || this._addAsset(path);
         this.copy(file);
@@ -200,15 +225,17 @@ class FileList extends EventEmitter {
     } else {
       debug(`Reading ${path}`);
       readFileAndCache(path, error => {
-        if (this.disposed) { return; }
         if (error) throw new Error(formatError('Reading', error));
         // .json files from node_modules should always be compiled
-        if (!ignored && (compiler && compiler.length) || deppack.isNpmJSON(path)) {
+        if (!isAsset && !ignored && (compiler && compiler.length) || deppack.isNpmJSON(path)) {
           const sourceFile = this.find(path) ||
             this._add(path, compiler, linters, isHelper);
           this.compile(sourceFile);
+        } else if (isStatic && !ignored) {
+          const staticFile = this.findStatic(path) || this._addStatic(path, compiler);
+          this.compile(staticFile);
         }
-        if (!this.initial) this.compileDependencyParents(path);
+        if (!this.initial) this.compileDependencyParents(path, isStatic);
         // When the file was ignored.
         this.resetTimer();
       });
@@ -217,13 +244,17 @@ class FileList extends EventEmitter {
 
   _unlink(path) {
     const ignored = this.isIgnored(path);
-    if (this.is('assets', path)) {
+    const isAsset = this.is('assets', path);
+    const isStatic = isAsset && this.findStatic(path);
+    const isRegularAsset = isAsset && !isStatic;
+
+    if (isRegularAsset) {
       if (!ignored) this.assets.splice(this.assets.indexOf(path), 1);
     } else {
       if (ignored) {
         this.compileDependencyParents(path);
       } else {
-        const file = this.find(path);
+        const file = isStatic ? this.findStatic(path) : this.find(path);
         if (file && !file.disposed) file.removed = true;
       }
     }

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -5,6 +5,7 @@ const anysort = require('anysort');
 const promisify = require('micro-promisify');
 const fsWriteFile = promisify(require('fs').writeFile);
 const mkdirp = promisify(require('mkdirp'));
+const unlink = promisify(require('fs').unlink);
 const deppack = require('deppack'); // needsProcessing, processFiles
 const helpers = require('../helpers'); // flatten, promisifyPlugin
 const processJob = require('../workers').processJob;
@@ -245,6 +246,21 @@ const generate = (path, targets, config, optimizers) => {
       }
       return data;
     });
+};
+
+generate.writeFile = writeFile;
+
+generate.writeStatics = (toRemove, toWrite) => {
+  const removePromise = toRemove.reduce((promise, file) => {
+    file.dispose();
+    return promise.then(() => unlink(file.destinationPath));
+  }, Promise.resolve());
+
+  const writePromise = toWrite.reduce((promise, file) => {
+    return promise.then(() => writeFile(file.destinationPath, file.compiled));
+  }, Promise.resolve());
+
+  return removePromise.then(() => writePromise);
 };
 
 generate.sortByConfig = sortByConfig;

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -65,6 +65,33 @@ const getDependencies = (data, path, compilerDeps, compiler) => {
   }
 };
 
+const compileStatic = (path, compiler) => {
+  let source;
+  return readFromCache(path).then(_source => {
+    source = _source;
+    return processJob(CompileStaticJob, {path, source, plugin: compiler});
+  }).then(data => {
+    return Object.assign({}, data, {source});
+  });
+};
+
+const _compileStatic = (path, source, compiler) => {
+  let compilationTime, compiled;
+  debug(`Compiling static ${path} @ ${compiler.constructor.name}`);
+  return compiler.compileStatic({ path, data: source }).then(_compiled => {
+    compilationTime = Date.now();
+    compiled = typeof _compiled === 'object' ? _compiled.data : _compiled;
+    if (compiler.getDependencies) {
+      return promisifyPlugin(2, compiler.getDependencies).call(compiler, source, path)
+        .then(null, error => prepareError('Dependency parsing', error));
+    } else {
+      return [];
+    }
+  }).then(dependencies => {
+    return {compiled, compilationTime, dependencies};
+  }, error => prepareError('Compiling', error));
+};
+
 const compilerChain = (previousPromise, compiler) => {
   return previousPromise.then(params => {
     if (!params) return Promise.resolve();
@@ -148,6 +175,27 @@ const CompileJob = {
   }
 };
 
+const CompileStaticJob = {
+  path: 'CompileStaticJob',
+
+  serialize(hash) {
+    return {path: hash.path, source: hash.source, pluginName: hash.plugin.brunchPluginName};
+  },
+
+  deserialize(ctx, hash) {
+    const plugin = ctx.staticCompilers.find(p => p.brunchPluginName === hash.pluginName);
+    return {path: hash.path, source: hash.source, plugin};
+  },
+
+  work(hash) {
+    const path = hash.path;
+    const source = hash.source;
+    const compiler = hash.plugin;
+
+    return _compileStatic(path, source, compiler);
+  }
+};
+
 exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
   if (deppack.isNpm(path)) {
     const _path = sysPath.resolve('.', path);
@@ -186,3 +234,5 @@ exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
 };
 
 exports.CompileJob = CompileJob;
+exports.CompileStaticJob = CompileStaticJob;
+exports.compileStatic = compileStatic;

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -18,7 +18,7 @@ const prepareError = (type, stringOrError) => {
     stringOrError;
   const error = new Error(string);
   error.code = type;
-  return error;
+  return Promise.reject(error);
 };
 
 
@@ -43,7 +43,7 @@ const lint = (data, path, linters) => {
         logger.warn(`Linting of ${path}: ${error}`);
         return Promise.resolve(data);
       } else {
-        return Promise.reject(prepareError('Linting', error));
+        return prepareError('Linting', error);
       }
     });
 };
@@ -101,14 +101,8 @@ const compilerChain = (previousPromise, compiler) => {
           return Promise.resolve({
             dependencies, compiled, source, sourceMap, path, jsExports
           });
-        }, error => {
-          return Promise.reject(prepareError('Dependency parsing', error));
-        });
-      }, error => {
-        return Promise.reject(prepareError('Compiling', error));
-      });
-  }, err => {
-    return Promise.reject(err);
+        }, error => prepareError('Dependency parsing', error));
+      }, error => prepareError('Compiling', error));
   });
 };
 
@@ -166,7 +160,7 @@ exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
       });
     }
 
-    return readFromCache(path).then(null, err => Promise.reject(prepareError('Read', err)))
+    return readFromCache(path).then(null, err => prepareError('Read', err))
       .then(source => {
         if (selectedCompilers.length) {
           return processJob(CompileJob, {path, source, linters: selectedLinters, compilers: selectedCompilers});
@@ -185,10 +179,9 @@ exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
   } else {
     return readFromCache(path).then(path => {
       return Promise.resolve(path);
-    }, (err) => {
-      return Promise.reject(prepareError('Read', err));
-    }).then(source => processJob(CompileJob, {path, source, linters, compilers}))
-      .then(deppack.exploreDeps(fileList));
+    }, err => prepareError('Read', err))
+    .then(source => processJob(CompileJob, {path, source, linters, compilers}))
+    .then(deppack.exploreDeps(fileList));
   }
 };
 

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -118,6 +118,21 @@ const checkWritten = (fileList, files, startTime) => {
   });
 };
 
+const writeStatic = (fileList, config, startTime) => {
+  const staticFiles = Array.from(fileList.staticFiles.values());
+  const errors = staticFiles.filter(f => f.error != null).map(formatWriteError);
+  if (errors.length > 0) return Promise.reject(errors.join(' ; '));
+
+  const changed = staticFiles.filter(f => f.compilationTime >= startTime || f.removed);
+
+  const toRemove = changed.filter(f => f.removed);
+  const toWrite = changed.filter(f => !f.removed);
+
+  debug(`Writing ${toWrite.length}/${staticFiles.length} static files, removing ${toRemove.length}`);
+
+  return generate.writeStatics(toRemove, toWrite);
+};
+
 const write = (fileList, config, joinConfig, optimizers, startTime) => {
   const files = getFiles(fileList, config, joinConfig);
   checkWritten(fileList, files, startTime);
@@ -151,7 +166,9 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
 
   return Promise.all(changed.map(file => {
     return generate(file.path, file.targets, config, optimizers);
-  })).then(() => Promise.resolve({changed, disposed}));
+  })).then(() => {
+    return writeStatic(fileList, config, startTime);
+  }).then(() => Promise.resolve({changed, disposed}));
 };
 
 module.exports = write;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -72,6 +72,7 @@ const loadPackages = (rootPath) => {
         try {
           return requireModule(depPath, dependency, true);
         } catch (error) {
+          logger.warn(`Loading of ${dependency} failed due to`, error);
           return null;
         }
       } else {

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -140,6 +140,11 @@ exports.init = (config, onCompile) => {
   const alwaysP = config.plugins.on;
   const plugins = unfiltered.filter(plugin => {
 
+    if (plugin.compileStatic && !plugin.staticTargetExtension) {
+      logger.warn(`${plugin.brunchPluginName} does not declare target extension for static files, skipping.`);
+      return false;
+    }
+
     // Backward compatibility for legacy optimizers.
     if (typeof plugin.minify === 'function') {
       if (!plugin.optimize) plugin.optimize = plugin.minify;
@@ -170,6 +175,7 @@ exports.init = (config, onCompile) => {
 
   // Get compilation methods.
   const compilers = plugins.filter(propIsFunction('compile'));
+  const staticCompilers = plugins.filter(propIsFunction('compileStatic'));
   const linters = plugins.filter(propIsFunction('lint'));
   const optimizers = plugins.filter(propIsFunction('optimize'));
   const teardowners = plugins.filter(propIsFunction('teardown'));
@@ -233,7 +239,7 @@ exports.init = (config, onCompile) => {
   speed.profile('Loaded plugins');
   const includes = getPluginIncludes(plugins);
   return Promise.resolve({
-    compilers, linters, includes, teardownBrunch, optimizers,
+    compilers, staticCompilers, linters, includes, teardownBrunch, optimizers,
     preCompilers, callCompileCallbacks
   });
 };
@@ -248,10 +254,9 @@ exports.init = (config, onCompile) => {
 
 const _patterns = {};
 const _neverMatchRe = /$0^/;
-const _getPattern = plugin => {
-  const ext = plugin.extension;
-  if (plugin.pattern) {
-    return plugin.pattern;
+const _getPattern = (ext, pattern) => {
+  if (pattern) {
+    return pattern;
   } else if (ext) {
     const re = _patterns[ext] || (_patterns[ext] = new RegExp('\\.' + ext + '$'));
     return re;
@@ -260,6 +265,14 @@ const _getPattern = plugin => {
   }
 };
 
-exports.isPluginFor = path => {
-  return plugin => _getPattern(plugin).test(path);
+exports.patternFor = (plugin, isStatic) => {
+  if (isStatic) {
+    return _getPattern(plugin.staticExtension || plugin.extension, plugin.staticPattern || plugin.pattern);
+  } else {
+    return _getPattern(plugin.extension, plugin.pattern);
+  }
+};
+
+exports.isPluginFor = (path, isStatic) => {
+  return plugin => exports.patternFor(plugin, isStatic).test(path);
 };

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -158,11 +158,15 @@ class BrunchWatcher {
     Object.freeze(cfg.npm.static);
 
     const nothingToCompile = "Nothing to compile. Most likely you don't have any source files yet, in which case, go ahead and create some! Otherwise, you probably don't have any plugin handling your source files (for plain javascript, that would be \"javascript-brunch\")";
+    const checkNothingToCompile = () => {
+      if (this.fileList.files.size === 0 && this.fileList.staticFiles.size === 0) {
+        logger.warn(nothingToCompile);
+      }
+    };
+
     if (!cfg.persistent) {
       process.on('exit', (code) => {
-        if (this.fileList.files.size === 0) {
-          logger.warn(nothingToCompile);
-        }
+        checkNothingToCompile();
         process.exit(code);
       });
     } else {
@@ -170,9 +174,7 @@ class BrunchWatcher {
         clearTimeout(this.nothingToCompileTimer);
       }
       this.nothingToCompileTimer = setTimeout(() => {
-        if (this.fileList.files.size === 0) {
-          logger.warn(nothingToCompile);
-        }
+        checkNothingToCompile();
       }, emptyFileListInterval);
     }
 

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -287,9 +287,14 @@ class BrunchWatcher {
    */
   changeFileList(path, isHelper) {
     path = sysPath.slashes(path);
-    const compiler = this.plugins.compilers.filter(plugins.isPluginFor(path));
-    const currentLinters = this.plugins.linters.filter(plugins.isPluginFor(path));
-    this.fileList.emit('change', path, compiler, currentLinters, isHelper);
+    if (this.fileList.is('assets', path)) {
+      const compiler = this.plugins.staticCompilers.filter(plugins.isPluginFor(path, true));
+      this.fileList.emit('change', path, compiler, [], isHelper);
+    } else {
+      const compiler = this.plugins.compilers.filter(plugins.isPluginFor(path));
+      const currentLinters = this.plugins.linters.filter(plugins.isPluginFor(path));
+      this.fileList.emit('change', path, compiler, currentLinters, isHelper);
+    }
   }
 
   compile(startTime, watcherReady) {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ava": "avajs/ava",
     "babel-eslint": "^6.0.4",
     "eslint": "^2.9.0",
-    "eslint-plugin-ava": "^2.3.1",
+    "eslint-plugin-ava": "avajs/eslint-plugin-ava",
     "fixturify": "^0.2.0",
     "fs-extra": "^0.30.0",
     "nyc": "^6.4.2",

--- a/test/_test_helper.js
+++ b/test/_test_helper.js
@@ -64,7 +64,7 @@ module.exports.fileExists = function fileExists(t, path) {
   }
 };
 
-module.exports.fileDoesNotExists = function fileDoesNotExists(t, path) {
+module.exports.fileDoesNotExist = function fileDoesNotExist(t, path) {
   try {
     fs.accessSync(path, fs.F_OK);
     t.fail(`File ${path} should not exist`);

--- a/test/watch.js
+++ b/test/watch.js
@@ -7,7 +7,7 @@ const {
   fileContains,
   fileDoesNotContains,
   fileExists,
-  fileDoesNotExists,
+  fileDoesNotExist,
   requestBrunchServer
 } = require('./_test_helper');
 const fixturify = require('fixturify');
@@ -268,9 +268,9 @@ test.serial.cb('reload config if it changes', t => {
 
   watch({}, function *main(compilation) {
     yield compilation();
-    fileDoesNotExists(t, 'dist/app.js.map');
-    fileDoesNotExists(t, 'dist/app.js');
-    fileDoesNotExists(t, 'dist/index.html');
+    fileDoesNotExist(t, 'dist/app.js.map');
+    fileDoesNotExist(t, 'dist/app.js');
+    fileDoesNotExist(t, 'dist/index.html');
     fileExists(t, 'public/app.js.map');
     fileExists(t, 'public/app.js');
     fileExists(t, 'public/index.html');


### PR DESCRIPTION
Changes to bring static asset compilation as to what @paulmillr and I have discussed.

This PR introduces an entirely new plugin API method: `compileStatic`. (`getDependencies` will then be used for both `compile` *and* `compileStatic` — as dependency discovery logic will be identical for both.)

The static asset compilation now will work on files from `app/assets`, this seems beneficial as it makes clear what will be compiled the regular way, and what will be compiled one-to-one. This means `app/index.jade` in will be a JS template, and `app/assets/index.jade` will turn into `public/index.html` — and both can be actually handled by the same plugin, `jade-brunch`, without having a separate plugin for this purpose.

- [x] tests
- [x] squash