### PR TITLE
Remove `preferGlobal: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "node": ">= 4.0",
     "npm": ">= 3.0"
   },
-  "preferGlobal": true,
   "dependencies": {
     "anymatch": "~1.3.0",
     "anysort": "~1.0.0",


### PR DESCRIPTION
It is very common at this point for brunch to be installed both globally and locally, or even locally-only within a project. This will eliminate the warning message npm currently spits out during local installation.