### PR TITLE
Default non-matching asset directory to root

### DIFF
--- a/lib/fs_utils/asset.js
+++ b/lib/fs_utils/asset.js
@@ -35,7 +35,7 @@ const replaceExt = (rel, compiler) => {
 // A static file that shall be copied to public directory.
 class Asset {
   constructor(path, publicPath, assetsConvention) {
-    const directory = getAssetDirectory(path, assetsConvention);
+    const directory = getAssetDirectory(path, assetsConvention) || '';
     const rel = sysPath.relative(directory, path);
     const destinationPath = sysPath.join(publicPath, rel);
     this.path = path;


### PR DESCRIPTION
If you modify `conventions.assets` to include matches for certain file types for example: `/\.component\.css$/` it would cause an error because `Asset` couldn't determine the base folder to use to copy to the output folder. This `undefined` was causing an issue for `sysPath.relative`. Defaulting to an empty string allows for these files to be copied over from the root.

This allows for JS to live next to HTML or CSS in the same folder and have the latter plucked out as assets while the code is compiled. Combined with the new static compilation functionality, this is quite powerful.

A further step in the future might allow for this default root to be customized (to say `app`) allowing references to these URLs to drop some leading folder segments.