### PR TITLE
Allow preCompile to run before every compile phase.

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -180,38 +180,40 @@ exports.init = (config, onCompile) => {
   const optimizers = plugins.filter(propIsFunction('optimize'));
   const teardowners = plugins.filter(propIsFunction('teardown'));
 
-  // Get plugin preCompile callbacks.
-  const preCompilers = plugins.filter(propIsFunction('preCompile'))
-  .map(plugin => {
-    return new Promise((resolve, reject) => {
-      if (plugin.preCompile.length === 1) {
-        plugin.preCompile(resolve);
-      } else {
-        const ret = plugin.preCompile();
-        if (ret && ret.then) {
-          ret.then(resolve, reject);
+  const preCompilers = () => {
+    // Get plugin preCompile callbacks.
+    const preCompilerPromises = plugins.filter(propIsFunction('preCompile')).map(plugin => {
+      return new Promise((resolve, reject) => {
+        if (plugin.preCompile.length === 1) {
+          plugin.preCompile(resolve);
         } else {
-          resolve();
+          const ret = plugin.preCompile();
+          if (ret && ret.then) {
+            ret.then(resolve, reject);
+          } else {
+            resolve();
+          }
         }
-      }
+      });
     });
-  });
 
-  // Add preCompile callback from config.
-  if (typeof config.hooks.preCompile === 'function') {
-    // => don't support arguments.
-    preCompilers.push(new Promise((resolve, reject) => {
-      if (config.hooks.preCompile.length === 1) {
-        config.hooks.preCompile(resolve);
-      } else {
-        const ret = config.hooks.preCompile();
-        if (ret && ret.then) {
-          ret.then(resolve, reject);
+    // Add preCompile callback from config.
+    if (typeof config.hooks.preCompile === 'function') {
+      // => don't support arguments.
+      preCompilerPromises.push(new Promise((resolve, reject) => {
+        if (config.hooks.preCompile.length === 1) {
+          config.hooks.preCompile(resolve);
         } else {
-          resolve();
+          const ret = config.hooks.preCompile();
+          if (ret && ret.then) {
+            ret.then(resolve, reject);
+          } else {
+            resolve();
+          }
         }
-      }
-    }));
+      }));
+    }
+    return preCompilerPromises;
   }
 
   // Get plugin onCompile callbacks.

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -214,7 +214,7 @@ exports.init = (config, onCompile) => {
       }));
     }
     return preCompilerPromises;
-  }
+  };
 
   // Get plugin onCompile callbacks.
   const callbacks = plugins.filter(propIsFunction('onCompile'))

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -306,7 +306,7 @@ class BrunchWatcher {
     const fileList = this.fileList;
     const watcher = this.watcher;
     const optimizers = this.plugins.optimizers;
-    const preCompilers = this.plugins.preCompilers;
+    const preCompilers = this.plugins.preCompilers();
     const callback = this.plugins.callCompileCallbacks;
 
     const assetErrors = fileList.getAssetErrors();


### PR DESCRIPTION
This change exposes plugins.preCompilers as a function that generates a new set
of preCompile promises on every compile phase.

This resolves #1406 and returns preCompile hooks to their original behaviour.