### PR TITLE
Prevent spawning a lot of processes when misusing brunch new

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ const checkOldBrunchNewSyntax = options => {
   if (oldSyntax) {
     const skeleton = opts[0];
     const path = opts[1];
-    loggy.error(`The \`brunch new ${skeleton} ${path}\` syntax is no longer supported. Use \`brunch new ${path} -s ${skeleton}\``);
+    loggy.error(`The 'brunch new ${skeleton} ${path}\' syntax is no longer supported. Use 'brunch new ${path} -s ${skeleton}'`);
     return true;
   }
 };


### PR DESCRIPTION
Closes GH-1413

It was caused by the use of backticks inside a logger message. When
spawning a growl notification, these caused the shell to start both of
the wrapped commands, resulting in a loop.

Couldn't find a way to properly escape these, so not using them
altogether for now.