### PR TITLE
Kill child process on sigterm signal

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -37,6 +37,10 @@ var runSeparateWatchProcess = function(cliPath) {
       runSeparateWatchProcess(cliPath);
     }
   });
+
+  process.on('SIGTERM', function() {
+    proc.kill();
+  });
 };
 
 var loadBrunch = function(libPath) {


### PR DESCRIPTION
Some process managers like [concurrently](https://github.com/kimmobrunfeldt/concurrently) sends a SIGTERM signal for the current process. But since the watcher server is actually called in a child process, this process wasn't being properly finished generating a phantom process. This PR fixes that.