### PR TITLE
Run Travis on Node.js 4 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 node_js:
+  - '4'
   - '5'
   - '6'
 before_install:


### PR DESCRIPTION
Since according to this comment, brunch supports Node.js 4:
https://github.com/babel/babel-brunch/pull/33#issuecomment-229130296