### PR TITLE
refactor & remove deep-assign

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 // Not using ES6 in that file since we want it to "launch" on older nodes.
 global.appStartTime = Date.now();

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -9,10 +9,7 @@ const aliases = {
   w: 'watch'
 };
 
-Object.keys(aliases).forEach(key => {
-  const value = aliases[key];
-  return aliases[value] = value;
-});
+Object.values(aliases).forEach(cmd => aliases[cmd] = cmd);
 
 program
   .version(require('../package.json').version, '-v, --version').usage('[command] [options]');
@@ -23,7 +20,7 @@ program.command('new [path]')
   .on('--help', () => {
     require('init-skeleton').printBanner('brunch new -s');
   })
-  .action(commands['new']);
+  .action(commands.new);
 
 program.command('build [path]')
   .description('Build a brunch project. Short-cut: b')
@@ -45,13 +42,13 @@ program.command('watch [path]')
   .action(commands.watch);
 
 const checkForRemovedOptions = (args, command) => {
-  const hasArg = name => args.indexOf(name) >= 0;
-  const hasCommand = (valid) => valid.indexOf(command) >= 0;
+  const hasArg = deprs => deprs.some(arg => args.includes(arg));
+  const hasCommand = valid => valid.includes(command);
   // Deprecations
-  if (hasArg('-c') || hasArg('--config')) {
+  if (hasArg(['-c', '--config'])) {
     return '--config has been removed. Use `-e / --environment` and specify custom envorinments in config';
   }
-  if (hasArg('-o') || hasArg('--optimize')) {
+  if (hasArg(['-o', '--optimize'])) {
     return '--optimize has been removed. Use `-p / --production`';
   }
   if (hasCommand(['g', 'd', 'generate', 'destroy'])) {
@@ -60,14 +57,12 @@ const checkForRemovedOptions = (args, command) => {
   if (hasCommand(['t', 'test'])) {
     return '`brunch test` command has been removed.\n\nUse mocha-phantomjs (http://metaskills.net/mocha-phantomjs/)\nsuccessor or similar:\n    npm install -g mocha-phantomjs\n    mocha-phantomjs [options] <your-html-file-or-url>';
   }
-  if (hasArg('-p')) {
+  const pIndex = args.indexOf('-p');
+  if (pIndex !== -1) {
     // if -p is followed by a number, the user probably wants to specify the port
     // the new option name for port is -P
-    const pIndex = args.indexOf('-p');
-    const next = args[pIndex + 1];
-    const oldSyntax = next && parseInt(next).toString() === next;
-
-    if (oldSyntax) {
+    const port = +args[pIndex + 1];
+    if (Number.isInteger(port)) {
       const corrected = ['brunch'].concat(args.slice(2)).map(x => x === '-p' ? '-P' : x).join(' ');
       return `The \`-p\` option is no longer used to specify the port. Use \`-P\` instead, e.g. \`${corrected}\``;
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,21 +1,18 @@
 'use strict';
+require('./polyfills');
+require('coffee-script').register();
+
 const fs = require('fs');
 const sysPath = require('./path');
 const exec = require('child_process').exec;
 const logger = require('loggy');
 const readComponents = require('read-components');
 const anymatch = require('anymatch');
-const coffee = require('coffee-script');
 const debug = require('debug')('brunch:config');
-const deepAssign = require('deep-assign');
-
-const deppack = require('deppack'); // isNpm
-const loadInit = deppack.loadInit;
+const helpers = require('./helpers');
+const deppack = require('deppack'); // isNpm, loadInit
 const mdls = require('./modules');
-
 const skemata = require('skemata');
-
-coffee.register();
 
 const mediator = {};
 const defaultConfigFilename = 'brunch-config';
@@ -44,7 +41,7 @@ const configBaseSchema = v.object({
   files: v.objects({
     keys: ['javascripts', 'templates', 'stylesheets'],
     warner: key => {
-      if (['app', 'test', 'vendor', 'assets'].indexOf(key) !== -1) {
+      if (['app', 'test', 'vendor', 'assets'].includes(key)) {
         return 'was removed, use `config.paths.watched` instead';
       }
     }
@@ -81,9 +78,9 @@ const configBaseSchema = v.object({
   }, false).default({}),
 
   conventions: v.object({
-    ignored: v.anymatch.default([/[\\\/]_/, /vendor[\\\/](node|j?ruby-.*|bundle)[\\\/]/]),
-    assets: v.anymatch.default(/assets[\\\/]/),
-    vendor: v.anymatch.default(/(^bower_components|node_modules|vendor)[\\\/]/)
+    ignored: v.anymatch.default([/[\\/]_/, /vendor[\\/](node|j?ruby-.*|bundle)[\\/]/]),
+    assets: v.anymatch.default(/assets[\\/]/),
+    vendor: v.anymatch.default(/(^bower_components|node_modules|vendor)[\\/]/)
   }).default({}),
 
   modules: v.object({
@@ -156,12 +153,12 @@ const configSchema = v.merge(
 const validateConfig = config => {
   const res = configSchema(config);
   const fmt = skemata.formatObject(res, 'config');
-  if (fmt && fmt.errors.length > 0) {
+  if (fmt && fmt.errors.length) {
     fmt.errors.forEach(error => {
       logger.error(`${error.path}: ${error.result}`);
     });
   }
-  if (fmt && fmt.warnings.length > 0) {
+  if (fmt && fmt.warnings.length) {
     fmt.warnings.forEach(warn => {
       logger.warn(`${warn.path}: ${warn.warning}`);
     });
@@ -179,26 +176,24 @@ const checkNpmModules = config => {
   return config;
 };
 
-const customDeepAssign = (object, properties, files) => {
-  const nestedObjs = Object.keys(files).map(file => files[file]);
-  const dontMerge = nestedObjs.indexOf(object) !== -1;
-  Object.keys(properties).forEach(key => {
-    const value = properties[key];
-    if (toString.call(value) === '[object Object]' && !dontMerge) {
-      if (object[key] == null) object[key] = {};
-      customDeepAssign(object[key], value, files);
-    } else {
-      if (dontMerge) {
-        // if either joinTo or entryPoints is overriden but not both, reset the other, as they are supposed to go hand-in-hand
-        const otherKey = key === 'joinTo' ? 'entryPoints' : key === 'entryPoints' ? 'joinTo' : null;
-        if (otherKey && otherKey in object && !(otherKey in properties)) {
-          delete object[otherKey];
-        }
+const dontMerge = files => {
+  const values = Object.values(files);
+
+  // this fn will be called on every nested object that will be merged
+  return (target, source) => {
+    if (!values.includes(target)) return () => true;
+
+    // this fn will be called on every enumerable entry in source
+    return key => {
+      // if either joinTo or entryPoints is overriden but not both, reset the other, as they are supposed to go hand-in-hand
+      const otherKey = key === 'joinTo' ? 'entryPoints' : key === 'entryPoints' ? 'joinTo' : null;
+      if (otherKey && otherKey in target && !(otherKey in source)) {
+        delete target[otherKey];
       }
-      object[key] = value;
-    }
-  });
-  return object;
+
+      return false;
+    };
+  };
 };
 
 const specials = {on: 'off', off: 'on'};
@@ -219,8 +214,8 @@ const applyOverrides = (config, options) => {
       if (prop === 'overrides' || !isObject) {
         return;
       }
-      config.overrides._default[prop] = {};
-      deepAssign(config.overrides._default[prop], config[prop]);
+      const override = config.overrides._default[prop] = {};
+      helpers.deepAssign(override, config[prop]);
     });
   }
   environments.forEach(override => {
@@ -235,34 +230,24 @@ const applyOverrides = (config, options) => {
         const item = overrideProps.plugins[v] || [];
         const cItem = config.plugins[v] || [];
         overrideProps.plugins[v] = item.concat(cItem.filter(plugin => {
-          const list = overrideProps.plugins[k] || [];
-          return list.indexOf(plugin) === -1;
+          const list = overrideProps.plugins[k];
+          return list && !list.includes(plugin);
         }));
       }
     });
-    customDeepAssign(config, overrideProps, config.files);
+    helpers.deepAssign(config, overrideProps, dontMerge(config.files));
   });
   // ensure server's public path takes overrides into account
   config.server.publicPath = config.paths.public;
   return config;
 };
 
-const deepFreeze = object => {
-  Object.keys(Object.freeze(object))
-    .map(key => object[key] && object[key] !== object.static)
-    .filter(value => {
-      return value && typeof value === 'object' && !Object.isFrozen(value);
-    })
-    .forEach(deepFreeze);
-  return object;
-};
-
 exports.install = (rootPath, command, isProduction) => {
   const prevDir = process.cwd();
-  logger.info('Installing ' + command + ' packages...');
+  logger.info(`Installing ${command} packages...`);
   process.chdir(rootPath);
 
-  const cmd = command + ' install' + (isProduction ? ' --production' : '');
+  const cmd = `${command} install${isProduction ? ' --production' : ''}`;
 
   return new Promise((resolve, reject) => {
     exec(cmd, (error, stdout, stderr) => {
@@ -298,20 +283,16 @@ const normalizeJoinConfig = joinTo => {
 };
 
 const normalizePluginHelpers = (items, subCfg) => {
-  const vendorRe = /vendor/i;
   if (!subCfg) return;
   if (!items) {
-    items = (() => {
-      const destFiles = Object.keys(subCfg);
-      const joinMatch = destFiles.find(file => subCfg[file]('vendor/.'));
-      if (joinMatch) return [joinMatch];
-      const nameMatch = destFiles.find(file => vendorRe.test(file));
-      if (nameMatch) return [nameMatch];
-      return [destFiles[0]];
-    })();
+    const destFiles = Object.keys(subCfg);
+    const joinMatch = destFiles.find(file => subCfg[file]('vendor/.'));
+    if (joinMatch) return [joinMatch];
+    const nameMatch = destFiles.find(file => /vendor/i.test(file));
+    if (nameMatch) return [nameMatch];
+    return [destFiles[0]];
   }
-  if (!Array.isArray(items)) items = [items];
-  return items;
+  return [].concat(items);
 };
 
 /* Converts `config.files[...].joinTo` to one format.
@@ -329,8 +310,7 @@ const normalizePluginHelpers = (items, subCfg) => {
 const createJoinConfig = (configFiles, paths) => {
   const types = Object.keys(configFiles);
 
-  const joinConfig = types.map(type => configFiles[type].joinTo)
-    .map(joinTo => joinTo || {})
+  const joinConfig = types.map(type => configFiles[type].joinTo || {})
     .map(normalizeJoinConfig)
     .reduce((cfg, subCfg, index) => {
       cfg[types[index]] = subCfg;
@@ -362,7 +342,7 @@ const createJoinConfig = (configFiles, paths) => {
       }
 
       Object.keys(fileCfg.entryPoints).forEach(target => {
-        const isTargetWatched = paths.watched.some(path => target.indexOf(path + '/') === 0);
+        const isTargetWatched = paths.watched.some(path => target.startsWith(`${path}/`));
         if (!isTargetWatched) {
           logger.warn(`The correct use of entry points is: \`'entryFile.js': 'outputFile.js'\`. You are trying to use '${target}' as an entry point, but it is probably an output file.`);
         }
@@ -375,7 +355,7 @@ const createJoinConfig = (configFiles, paths) => {
         const normalizedEntryCfg = normalizeJoinConfig(entryCfg);
 
         Object.keys(normalizedEntryCfg).forEach(path => {
-          if (outPaths.indexOf(path) !== -1) {
+          if (outPaths.includes(path)) {
             logger.warn(`'${path}' is already used by another entry point, can't add it to config.files.${type}.entryPoints for '${target}'`);
             delete normalizedEntryCfg[path];
             return;
@@ -395,9 +375,7 @@ const setConfigDefaults = exports.setConfigDefaults = (config, configPath) => {
   const join = (parent, name) => {
     return sysPath.isAbsolute(name) ? name : sysPath.join(config.paths[parent], name);
   };
-  const joinRoot = name => {
-    return join('root', name);
-  };
+  const joinRoot = name => join('root', name);
 
   // Paths.
   const paths = config.paths;
@@ -436,10 +414,11 @@ const normalizeConfig = config => {
   const normalized = {};
   normalized.join = createJoinConfig(config.files, config.paths);
   const mod = config.modules;
-  normalized.modules = {};
-  normalized.modules.wrapper = mdls.normalizeWrapper(mod.wrapper, config.modules.nameCleaner);
-  normalized.modules.definition = mdls.normalizeDefinition(mod.definition);
-  normalized.modules.autoRequire = mod.autoRequire;
+  normalized.modules = {
+    wrapper: mdls.normalizeWrapper(mod.wrapper, config.modules.nameCleaner),
+    definition: mdls.normalizeDefinition(mod.definition),
+    autoRequire: mod.autoRequire
+  };
   normalized.conventions = {};
   Object.keys(config.conventions).forEach(name => {
     const fn = normalizeChecker(config.conventions[name]);
@@ -476,26 +455,24 @@ const addDefaultServer = config => {
     const resolved = require.resolve(sysPath.resolve(defaultServerFilename));
     try {
       require(resolved);
-    } catch (error2) {
+    } catch (error) {
       // Do nothing.
     }
     if (config.server.path == null) {
       config.server.path = resolved;
     }
-  } catch (error1) {
+  } catch (error) {
     // Do nothing.
   }
   return config;
 };
 
-const enoentRe = /ENOENT/;
 const loadComponents = (config, type) => {
   // Since readComponents call its callback with many arguments, we hate to wrap it manually
   return new Promise((resolve, reject) => {
     readComponents('.', type, (err, components) => {
-      if (err) return reject(err);
-
-      return resolve({components});
+      if (err) reject(err);
+      else resolve({components});
     });
   }).then(o => {
     const components = o.components || [];
@@ -507,47 +484,36 @@ const loadComponents = (config, type) => {
           return b.sortingLevel - a.sortingLevel;
         }
       })
-      .reduce(((flat, component) => flat.concat(component.files)), []);
+      .reduce((flat, component) => flat.concat(component.files), []);
     return {components, order};
   }, error => {
-    const errStr = error.toString();
     if (error.code === 'NO_BOWER_JSON') {
       logger.error('You probably need to execute `bower install` here.', error);
-    } else if (!enoentRe.test(errStr)) {
+    } else if (!/ENOENT/.test(error)) {
       logger.error(error);
     }
 
-      // Returning default values
+    // Returning default values
     return {components: [], aliases: [], order: []};
   });
 };
 
 const loadNpm = (config) => {
   return new Promise((resolve, reject) => {
+    const paths = config.paths;
+    const rootPath = sysPath.resolve(paths.root);
+    const jsonPath = sysPath.resolve(rootPath, paths.packageConfig);
     try {
-      const paths = config.paths;
-      const rootPath = sysPath.resolve(paths.root);
-      const jsonPath = sysPath.resolve(rootPath, paths.packageConfig);
-      let json;
-      try {
-        json = require(jsonPath);
-      } catch (error) {
-        let message;
-        if (error.message.indexOf('Cannot find module') !== -1) {
-          message = "No package.json was found. That's where brunch plugins need to be listed. Plugins tell Brunch how to compile your files, so without any plugins Brunch won't know what to do. To get started, run `npm init` to generate a package.json file and `npm install --save javascript-brunch css-brunch` to install and save plugins for regular JS and CSS.";
-        } else if (error.message.indexOf('SyntaxError:') !== -1 || error.message.indexOf('Unexpected end of input') !== -1) {
-          message = `package.json has invalid syntax (${error.message})`;
-        }
-        if (message) {
-          return reject(new Error(message));
-        } else {
-          return reject(error);
-        }
+      var json = require(jsonPath);
+    } catch (error) {
+      if (error.message.includes('Cannot find module')) {
+        throw new Error("No package.json was found. That's where brunch plugins need to be listed. Plugins tell Brunch how to compile your files, so without any plugins Brunch won't know what to do. To get started, run `npm init` to generate a package.json file and `npm install --save javascript-brunch css-brunch` to install and save plugins for regular JS and CSS.");
+      } else if (error instanceof SyntaxError || error.message.includes('Unexpected end of input')) {
+        throw new Error(`package.json has invalid syntax (${error.message})`);
       }
-      return loadInit(config, json).then(resolve, reject);
-    } catch (e) {
-      return reject(e);
+      throw error;
     }
+    deppack.loadInit(config, json).then(resolve, reject);
   });
 };
 
@@ -589,39 +555,32 @@ const tryToLoad = (configPath, fallbackHandler) => {
   let fullPath;
   let basename = configPath;
 
-  let pkg;
-
   try {
-    pkg = require(sysPath.resolve('.', 'package.json'));
+    var pkg = require(sysPath.resolve('.', 'package.json'));
   } catch (e) {
     // error
   }
 
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     debug(`Trying to load ${configPath}`);
-    let resolved;
-    try {
-      // Assign fullPath in two steps in case require.resolve throws.
-      fullPath = sysPath.resolve(configPath);
-      fullPath = require.resolve(fullPath);
-      delete require.cache[fullPath];
-      resolved = require(fullPath);
-    } catch (e) {
-      return reject(e);
-    }
+    // Assign fullPath in two steps in case require.resolve throws.
+    fullPath = sysPath.resolve(configPath);
+    fullPath = require.resolve(fullPath);
+    delete require.cache[fullPath];
+    const resolved = require(fullPath);
     basename = sysPath.basename(fullPath);
-    return resolve(resolved);
+    resolve(resolved);
   }).then(obj => {
     const config = obj.config || obj;
     if (!config) {
-      return Promise.reject(new Error(`${basename} must be a valid object`));
+      throw new Error(`${basename} must be a valid object`);
     }
     if (!('files' in config)) {
-      return Promise.reject(new Error(`${basename} must have "files" property. Here's a minimal brunch-config.js to get you started:\n${minimalConfig}`));
+      throw new Error(`${basename} must have "files" property. Here's a minimal brunch-config.js to get you started:\n${minimalConfig}`);
     }
     return config;
   }).catch(error => {
-    const isConfigRequireError = error.toString().indexOf(`'${fullPath}'`) !== -1;
+    const isConfigRequireError = error.toString().includes(`'${fullPath}'`);
     if (error.code === 'MODULE_NOT_FOUND' && isConfigRequireError) {
       if (!fallbackHandler) {
         fallbackHandler = () => {
@@ -637,37 +596,38 @@ const tryToLoad = (configPath, fallbackHandler) => {
 
       fallbackHandler();
     } else if (pkg && error.code === 'MODULE_NOT_FOUND') {
-      const modRe = /Cannot find module '([\w\d-\/]+)'/;
-      const mod = modRe.exec(error.toString())[1];
-      if (mod && mod[0] !== '.') {
-        const topLevelMod = mod.split('/')[0];
-        const pkgs = Object.assign({}, pkg.dependencies || {}, pkg.devDependencies || {});
-        if (topLevelMod in pkgs) {
+      const modRe = /Cannot find module '([\w-/]+)'/;
+      const mod = modRe.exec(error)[1];
+      if (mod && !mod.startsWith('.')) {
+        const topLevelMod = mod.split('/', 1)[0];
+        const deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+        if (topLevelMod in deps) {
           logger.warn(`Config requires '${topLevelMod}' which is in package.json but wasn't yet installed. Trying to install...`);
           return exports.install('.', 'npm').then(() => tryToLoad(configPath));
         }
       }
     }
     error.code = 'BRSYNTAX';
-    error.message = 'Failed to load brunch config - ' + error.message;
-    return Promise.reject(error);
+    error.message = `Failed to load brunch config - ${error.message}`;
+    throw error;
   });
 };
 
+const dontFreeze = ['static', 'overrides'];
+
 exports.loadConfig = (persistent, opts, fromWorker) => {
-  const noop = (config) => config;
   const configPath = opts.config || defaultConfigFilename;
   const options = initParams(persistent, opts) || {};
   return tryToLoad(configPath)
     .then(validateConfig)
     .then(checkNpmModules)
     .then(config => setConfigDefaults(config, configPath))
-    .then(fromWorker ? noop : addDefaultServer)
+    .then(fromWorker || addDefaultServer)
     .then(config => applyOverrides(config, options))
-    .then(config => deepAssign(config, options))
+    .then(config => helpers.deepAssign(config, options))
     .then(normalizeConfig)
-    .then(fromWorker ? noop : addPackageManagers)
-    .then(deepFreeze);
+    .then(fromWorker || addPackageManagers)
+    .then(helpers.deepFreeze(dontFreeze));
 };
 
 // workerk don't need default server, deprecation warnings, or package manager support
@@ -695,7 +655,7 @@ const initParams = (persistent, options) => {
 
   const env = options.env;
   const params = {
-    env: (env && env.split(',')) || []
+    env: env ? env.split(',') : []
   };
   if (options.production != null || options.optimize != null) {
     mediator.isProduction = true;

--- a/lib/fs_utils/asset.js
+++ b/lib/fs_utils/asset.js
@@ -5,7 +5,7 @@ const copyFile = require('quickly-copy-file');
 const prettify = require('../helpers').prettify;
 const isIgnored = require('./common').isIgnored;
 const pipeline = require('./pipeline');
-const plugins = require('../plugins');
+const patternFor = require('../plugins').patternFor;
 const logger = require('loggy');
 
 // Asset: Simple abstraction on top of static assets that are not compiled.
@@ -15,20 +15,19 @@ const logger = require('loggy');
 // => 'app/assets/'
 // Returns String.
 const getAssetDirectory = (path, convention) => {
-  const sep = sysPath.sep;
   const split = path.split('/');
 
   // Creates list similar to:
   // ['app/', 'app/assets/', 'app/assets/thing/', 'app/assets/thing/item.html/']
   return split.map((part, index) => {
-    return split.slice(0, index).concat([part, '']).join(sep);
+    return split.slice(0, index).concat(part, '').join(sysPath.sep);
   }).find(convention);
 };
 
 const replaceExt = (rel, compiler) => {
-  const oldRe = plugins.patternFor(compiler, true);
+  const oldRe = patternFor(compiler, true);
   const newExt = compiler.staticTargetExtension;
-  return rel.replace(oldRe, '.' + newExt);
+  return rel.replace(oldRe, `.${newExt}`);
 };
 
 
@@ -58,14 +57,12 @@ class Asset {
       debug(`Copied ${path}`);
       this.updateTime();
       this.error = null;
-      return Promise.resolve();
     }, err => {
       debug(`Cannot copy ${path}: ${err}`);
       this.updateTime();
       const error = new Error(err);
       error.code = 'Copying';
-      this.error = error;
-      return Promise.reject(this.error);
+      throw this.error = error;
     });
   }
 
@@ -125,5 +122,5 @@ class CompiledAsset {
   }
 }
 
+Asset.Static = CompiledAsset;
 module.exports = Asset;
-module.exports.Static = CompiledAsset;

--- a/lib/fs_utils/file_list.js
+++ b/lib/fs_utils/file_list.js
@@ -53,31 +53,30 @@ class FileList extends EventEmitter {
 
   getAssetErrors() {
     const invalid = this.assets.filter(a => a.error);
-    if (invalid.length > 0) {
+    if (invalid.length) {
       return invalid.map(iv => formatError(iv.error, iv.path));
-    } else {
-      return null;
     }
+    return null;
   }
 
   isIgnored(path, test) {
     if (deppack.isNpm(path)) return false;
     if (!test) test = this.conventions.ignored;
-    if (this.configPaths.indexOf(path) >= 0) return true;
+    if (this.configPaths.includes(path)) return true;
     switch (toString.call(test).slice(8, -1)) {
       case 'RegExp': return path.match(test);
       case 'Function': return test(path);
       case 'String': return normalize(path).startsWith(normalize(test));
       case 'Array': return test.some(subTest => this.isIgnored(path, subTest));
-      default: return false;
     }
+    return false;
   }
 
   is(name, path) {
     const convention = this.conventions[name];
     if (!convention) return false;
     if (typeof convention !== 'function') {
-      throw new TypeError('Invalid convention ' + convention);
+      throw new TypeError(`Invalid convention ${convention}`);
     }
     return convention(path);
   }
@@ -126,9 +125,7 @@ class FileList extends EventEmitter {
     const files = isStatic ? this.staticFiles : this.files;
     files.forEach((dependent, fpath) => {
       const deps = dependent.dependencies;
-      const isDep = deps && deps.length > 0 &&
-        deps.indexOf(path) >= 0 &&
-        !this.compiled.has(fpath);
+      const isDep = deps && deps.includes(path) && !this.compiled.has(fpath);
       if (!isDep) return;
       paths.push(fpath);
       parents.push(dependent);
@@ -163,7 +160,7 @@ class FileList extends EventEmitter {
   copy(asset) {
     const path = asset.path;
     const resetCopy = (p) => {
-      if (this.disposed) { return p; }
+      if (this.disposed) return p;
       this.copying.delete(path);
       this.resetTimer();
       return p;
@@ -196,12 +193,11 @@ class FileList extends EventEmitter {
       return file;
     } catch (e) {
       require('loggy').error(e);
-      return;
     }
   }
 
   _change(path, compiler, linters, isHelper) {
-    if (this.disposed) { return; }
+    if (this.disposed) return;
 
     const ignored = this.isIgnored(path);
     const isAsset = this.is('assets', path);
@@ -216,7 +212,7 @@ class FileList extends EventEmitter {
     } else {
       debug(`Reading ${path}`);
       readFileAndCache(path, error => {
-        if (this.disposed) { return; }
+        if (this.disposed) return;
         if (error) throw new Error(formatError('Reading', error));
         // .json files from node_modules should always be compiled
         if (!isAsset && !ignored && (compiler && compiler.length) || deppack.isNpmJSON(path)) {

--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -49,9 +49,9 @@ const sortByConfig = (files, config) => {
 };
 
 const extractOrder = (files, config) => {
-  const types = files.map(file => file.type + 's');
+  const types = files.map(file => `${file.type}s`);
   const orders = Object.keys(config.files)
-    .filter(key => types.indexOf(key) >= 0)
+    .filter(key => types.includes(key))
     .map(key => config.files[key].order || {});
   const before = helpers.flatten(orders.map(type => type.before || []));
   const after = helpers.flatten(orders.map(type => type.after || []));
@@ -72,7 +72,6 @@ const sort = (files, config, joinToValue) => {
 
 
 // New.
-const semi = ';';
 const concat = (files, path, definitionFn, autoRequire, config) => {
   if (autoRequire == null) autoRequire = [];
   const isJs = !!definitionFn;
@@ -85,7 +84,7 @@ const concat = (files, path, definitionFn, autoRequire, config) => {
   const processor = (file) => {
     root.add(file.node);
     const data = file.node.isIdentity ? file.data : file.source;
-    if (isJs && data.trim().substr(-1) !== semi) root.add(semi);
+    if (isJs && !data.trim().endsWith(';')) root.add(';');
     return root.setSourceContent(file.node.source, data);
   };
 
@@ -96,11 +95,11 @@ const concat = (files, path, definitionFn, autoRequire, config) => {
     const isHmr = isHmrEnabled(config);
 
     const moduleFiles = files.filter(f => isNpm(f) || f.file.isModule);
-    const nonModuleFiles = files.filter(f => moduleFiles.indexOf(f) === -1);
+    const nonModuleFiles = files.filter(f => !moduleFiles.includes(f));
 
     const definition = definitionFn(path, root.sourceContents);
     const generateModuleFiles = () => {
-      if (config.npm.enabled && moduleFiles.length > 0) {
+      if (config.npm.enabled && moduleFiles.length) {
         deppack.processFiles(root, moduleFiles, processor);
       } else {
         moduleFiles.forEach(processor);
@@ -184,7 +183,7 @@ const runOptimizer = (optimizer, params) => {
     const optimized = typeof res === 'string' ? {data: res} : res;
     const data = optimized.data;
     const map = prepareSourceMap(optimized.map, sourceFiles) || unoptMap;
-    return Promise.resolve({data, path, map, sourceFiles, code: data});
+    return {data, path, map, sourceFiles, code: data};
   });
 };
 
@@ -202,13 +201,12 @@ const optimize = (data, map, path, optimizers, sourceFiles) => {
 const jsTypes = ['javascript', 'template'];
 
 const generate = (path, targets, config, optimizers) => {
-  const type = targets.some(file => jsTypes.indexOf(file.type) >= 0) ?
+  const type = targets.some(file => jsTypes.includes(file.type)) ?
     'javascript' : 'stylesheet';
 
   const foptim = optimizers.filter(optimizer => optimizer.type === type);
-  const len = config.paths['public'].length + 1;
-  const joinKey = path.slice(len);
-  const typeConfig = config.files[type + 's'] || {};
+  const joinKey = path.slice(config.paths.public.length + 1);
+  const typeConfig = config.files[`${type}s`] || {};
   const joinToValue = (typeConfig.joinTo && typeConfig.joinTo[joinKey]) || {};
   const sorted = sort(targets, config, joinToValue);
   const norm = config._normalized;
@@ -221,20 +219,18 @@ const generate = (path, targets, config, optimizers) => {
   const code = cc.code;
   const map = cc.map;
   const withMaps = map && config.sourceMaps;
-  const mapPath = path + '.map';
+  const mapPath = `${path}.map`;
   return optimize(code, map, path, foptim, targets)
     .then(data => {
       if (withMaps) {
         const mapRoute = config.sourceMaps === 'absoluteUrl' ?
-          mapPath.replace(config.paths['public'], '') :
+          mapPath.replace(config.paths.public, '') :
           sysPath.basename(mapPath);
         const controlChar = config.sourceMaps === 'old' ? '@' : '#';
         const end = `${controlChar} sourceMappingURL=${mapRoute}`;
         data.code += type === 'javascript' ? `\n//${end}` : `\n/*${end}*/`;
       }
       return data;
-    }, error => {
-      return Promise.reject(error);
     })
     .then(data => {
       return writeFile(path, data.code).then(() => data);

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -18,36 +18,24 @@ const prepareError = (type, stringOrError) => {
     stringOrError;
   const error = new Error(string);
   error.code = type;
-  return Promise.reject(error);
+  throw error;
 };
-
 
 // Run all linters.
 const lint = (data, path, linters) => {
-  const reduceLinter = (previousPromise, linter) => {
+  return linters.reduce((previousPromise, linter) => {
     debug(`Linting '${path}' with '${linter.constructor.name}'`);
     return previousPromise.then(() => {
       return callPlugin(linter, linter.lint, 2, [data, path]);
-    }, err => {
-      return Promise.reject(err);
     });
-  };
-
-  return Promise.resolve(linters)
-    .then(linters => {
-      return linters.reduce(reduceLinter, Promise.resolve());
-    }).then(() => {
-      return Promise.resolve(data);
-    }, error => {
-      if (error.toString().match(warningRe)) {
-        logger.warn(`Linting of ${path}: ${error}`);
-        return Promise.resolve(data);
-      } else {
-        return prepareError('Linting', error);
-      }
-    });
+  }, Promise.resolve()).then(() => data, error => {
+    if (/^warn\:\s/i.test(error)) {
+      logger.warn(`Linting of ${path}: ${error}`);
+      return data;
+    }
+    return prepareError('Linting', error);
+  });
 };
-
 
 // Extract files that depend on current file.
 const getDependencies = (data, path, compilerDeps, compiler) => {
@@ -63,9 +51,8 @@ const getDependencies = (data, path, compilerDeps, compiler) => {
       .then(deps => {
         return deps.map(x => sysPath.normalize(x));
       });
-  } else {
-    return Promise.resolve(compilerDeps || []);
   }
+  return Promise.resolve(compilerDeps || []);
 };
 
 const compileStatic = (path, compiler) => {
@@ -83,13 +70,12 @@ const _compileStatic = (path, source, compiler) => {
   debug(`Compiling static ${path} @ ${compiler.constructor.name}`);
   return compiler.compileStatic({ path, data: source }).then(_compiled => {
     compilationTime = Date.now();
-    compiled = typeof _compiled === 'object' ? _compiled.data : _compiled;
+    compiled = _compiled && typeof _compiled === 'object' ? _compiled.data : _compiled;
     if (compiler.getDependencies) {
       return callPlugin(compiler, compiler.getDependencies, 2, [source, path])
-        .then(null, error => prepareError('Dependency parsing', error));
-    } else {
-      return [];
+        .catch(error => prepareError('Dependency parsing', error));
     }
+    return [];
   }).then(dependencies => {
     return {compiled, compilationTime, dependencies};
   }, error => prepareError('Compiling', error));
@@ -97,7 +83,7 @@ const _compileStatic = (path, source, compiler) => {
 
 const compilerChain = (previousPromise, compiler) => {
   return previousPromise.then(params => {
-    if (!params) return Promise.resolve();
+    if (!params) return;
 
     // const dependencies = params.dependencies;
     const compiled = params.compiled;
@@ -108,7 +94,6 @@ const compilerChain = (previousPromise, compiler) => {
     const compilerData = compiled || source;
     const fn = compiler.compile;
 
-
     // New API: compile({data, path}, callback)
     // Old API: compile(data, path, callback)
     const compilerArgs = (fn.length === 2 || fn.length === 1) ?
@@ -116,22 +101,18 @@ const compilerChain = (previousPromise, compiler) => {
       [compilerData, path];
     return callPlugin(compiler, fn, 1, compilerArgs, `compile ${path}`)
       .then(result => {
-        if (result == null) return Promise.resolve();
+        if (result == null) return;
         const isObject = toString.call(result) === '[object Object]';
         const compiled = isObject ? result.data : result;
         const compilerDeps = isObject && result.dependencies;
         const jsExports = isObject && result.exports;
         if (isObject) sourceMap = result.map;
         if (compiled == null) {
-          return Promise.reject(new Error(
-            `Brunch SourceFile: file ${path} data is invalid`
-          ));
+          throw new Error(`Brunch SourceFile: file ${path} data is invalid`);
         }
         return getDependencies(source, path, compilerDeps, compiler)
         .then(dependencies => {
-          return Promise.resolve({
-            dependencies, compiled, source, sourceMap, path, jsExports
-          });
+          return {dependencies, compiled, source, sourceMap, path, jsExports};
         }, error => prepareError('Dependency parsing', error));
       }, error => prepareError('Compiling', error));
   });
@@ -143,8 +124,6 @@ const compile = (source, path, compilers) => {
     return compilers.reduce(compilerChain, Promise.resolve(params));
   });
 };
-
-const warningRe = /^warn\:\s/i;
 
 const CompileJob = {
   path: 'CompileJob',
@@ -204,37 +183,31 @@ exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
   if (deppack.isNpm(path)) {
     const _path = sysPath.resolve('.', path);
     const selectedLinters = [];
-    let selectedCompilers = [];
+    const selectedCompilers = !depCompilers.length ? [] : compilers.filter(compiler => {
+      const name = compiler.brunchPluginName;
+      return name === 'javascript-brunch' || depCompilers.includes(name);
+    });
 
-    if (depCompilers.length) {
-      selectedCompilers = compilers.filter(comp => {
-        return depCompilers.indexOf(comp.brunchPluginName) !== -1 || comp.brunchPluginName === 'javascript-brunch';
-      });
-    }
-
-    return readFromCache(path).then(null, err => prepareError('Read', err))
+    return readFromCache(path).catch(error => prepareError('Read', error))
       .then(source => {
         if (selectedCompilers.length) {
           return processJob(CompileJob, {path, source, linters: selectedLinters, compilers: selectedCompilers});
-        } else {
-          return {compiled: source, source, path};
         }
+        return {compiled: source, source, path};
       }).then(file => {
         return deppack.wrapSourceInModule(file.compiled, _path).then(compiled => {
           file.compiled = compiled;
           return file;
         });
       }).then(file => {
-        return {compiled: file.compiled, source: file.source, path: path};
-      }
-      ).then(deppack.exploreDeps(fileList));
-  } else {
-    return readFromCache(path).then(path => {
-      return Promise.resolve(path);
-    }, err => prepareError('Read', err))
+        return {compiled: file.compiled, source: file.source, path};
+      }).then(deppack.exploreDeps(fileList));
+  }
+
+  return readFromCache(path)
+    .catch(error => prepareError('Read', error))
     .then(source => processJob(CompileJob, {path, source, linters, compilers}))
     .then(deppack.exploreDeps(fileList));
-  }
 };
 
 exports.CompileJob = CompileJob;

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -85,10 +85,10 @@ const updateCache = (path, cache, error, result, wrap, jsWrap) => {
   cache.compilationTime = Date.now();
   return updateMap(path, compiled, wrapped, result.sourceMap).then(node => {
     cache.targets = {};
-    cache.targets[cache.type] = { data: compiled, node: node };
+    cache.targets[cache.type] = { data: compiled, node };
     if (result.jsExports && cache.type !== 'javascript') {
       const jsNode = updateJsExportsNode(path, result.jsExports, jsWrap(result.jsExports));
-      cache.targets['javascript'] = { data: result.jsExports, node: jsNode, addon: true };
+      cache.targets.javascript = { data: result.jsExports, node: jsNode, addon: true };
     }
     return cache;
   });
@@ -100,14 +100,12 @@ const makeWrapper = (wrapper, path, isWrapped, isntModule) => {
 
 const makeCompiler = (path, cache, linters, compilers, wrap, jsWrap, depCompilers) => {
   const normalizedPath = path;
-  return () => {
-    return pipeline(normalizedPath, linters, compilers, cache.fileList, depCompilers)
-      .then(data => {
-        return updateCache(normalizedPath, cache, null, data, wrap, jsWrap).then(() => null);
-      }, error => {
-        return updateCache(normalizedPath, cache, error, null, wrap, jsWrap).then(() => Promise.reject(error));
-      });
-  };
+  return () => pipeline(normalizedPath, linters, compilers, cache.fileList, depCompilers)
+    .then(data => {
+      return updateCache(normalizedPath, cache, null, data, wrap, jsWrap).then(() => null);
+    }, error => {
+      return updateCache(normalizedPath, cache, error, null, wrap, jsWrap).then(() => { throw error; });
+    });
 };
 
 // A file that will be compiled by brunch.

--- a/lib/fs_utils/write.js
+++ b/lib/fs_utils/write.js
@@ -18,16 +18,14 @@ const formatWriteError = sourceFile => {
 };
 
 const getPaths = (type, isHelper, path, sourceFileJoinConfig) => {
-  const hlprs = sourceFileJoinConfig.pluginHelpers;
+  const helpers = sourceFileJoinConfig.pluginHelpers;
   return Object.keys(sourceFileJoinConfig)
-  .filter(key => key !== 'pluginHelpers')
-  .filter(generatedFilePath => {
-    if (isHelper) {
-      return hlprs.indexOf(generatedFilePath) >= 0;
-    } else {
-      const checker = sourceFileJoinConfig[generatedFilePath];
-      return checker(path);
-    }
+  .filter(key /* generatedFilePath */ => {
+    if (key === 'pluginHelpers') return;
+    if (isHelper) return helpers.includes(key);
+
+    const checker = sourceFileJoinConfig[key];
+    return checker(path);
   });
 };
 
@@ -39,10 +37,10 @@ const filterTargetsForEntry = (files, type, entry) => {
       path: file.path,
       data: target.data,
       node: target.node,
-      type: type,
+      type,
       isHelper: file.isHelper,
       source: mainTarget ? file.source : target.data,
-      file: file
+      file
     };
   };
 
@@ -56,7 +54,7 @@ const filterTargetsForEntry = (files, type, entry) => {
   if (entry === '*') return targets;
   // otherwise, if normal entry point, gather its deps
   const depPaths = deppack.getAllDependents(entry);
-  return targets.filter(t => depPaths.indexOf(t.path) !== -1);
+  return targets.filter(t => depPaths.includes(t.path));
 };
 
 const getFiles = (fileList, config, joinConfig) => {
@@ -109,7 +107,7 @@ const checkWritten = (fileList, files, startTime) => {
       Object.keys(file.targets).forEach(type => {
         const target = file.targets[type];
         const allTargets = allWrittenTargets[type] || [];
-        if (allTargets.indexOf(file.path) === -1 && target.data) {
+        if (!allTargets.includes(file.path) && target.data) {
           logger.warn(`${file.path} compiled, but not written. ` +
             `Check your ${type}s.joinTo config`);
         }
@@ -121,7 +119,7 @@ const checkWritten = (fileList, files, startTime) => {
 const writeStatic = (fileList, config, startTime) => {
   const staticFiles = Array.from(fileList.staticFiles.values());
   const errors = staticFiles.filter(f => f.error != null).map(formatWriteError);
-  if (errors.length > 0) return Promise.reject(errors.join(' ; '));
+  if (errors.length) throw errors.join(' ; ');
 
   const changed = staticFiles.filter(f => f.compilationTime >= startTime || f.removed);
 
@@ -144,7 +142,7 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
     })
     .reduce((a, b) => a.concat(b), []);
 
-  if (errors.length > 0) return Promise.reject(errors.join(' ; '));
+  if (errors.length) return Promise.reject(errors.join(' ; '));
 
   const changed = files.filter(changedSince(startTime));
   debug(`Writing ${changed.length}/${files.length} files`);
@@ -168,7 +166,9 @@ const write = (fileList, config, joinConfig, optimizers, startTime) => {
     return generate(file.path, file.targets, config, optimizers);
   })).then(() => {
     return writeStatic(fileList, config, startTime);
-  }).then(() => Promise.resolve({changed, disposed}));
+  }).then(() => {
+    return {changed, disposed};
+  });
 };
 
 module.exports = write;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -12,47 +12,64 @@ exports.flatten = (array) => [].concat.apply([], array);
 exports.promisifyPlugin = (arity, fn) => fn.length === arity ? fn : promisify(fn);
 
 exports.safePromise = (promise, intervalTime, timeoutMessage) => {
-  let resolved;
+  let pending = true;
   return new Promise((resolve, reject) => {
     promise.then(val => {
-      if (resolved) return;
-      resolved = true;
+      pending = false;
       resolve(val);
     }, err => {
-      if (resolved) return;
-      resolved = true;
+      pending = false;
       reject(err);
     });
 
     const interval = setInterval(() => {
-      if (resolved) {
-        clearInterval(interval);
-        return;
-      }
-
-      logger.warn(timeoutMessage);
+      if (pending) logger.warn(timeoutMessage);
+      else clearInterval(interval);
     }, intervalTime);
   });
+};
+
+const deepAssign = exports.deepAssign = (target, source, filter) => {
+  const shouldMerge = typeof filter === 'function'
+    && filter(target, source)
+    || (() => true);
+
+  Object.keys(source).forEach(key => {
+    const value = source[key];
+    const isObject = toString.call(value) === '[object Object]';
+    if (isObject && shouldMerge(key, value)) {
+      let nested = target[key];
+      if (nested == null) nested = target[key] = {};
+      deepAssign(nested, value, filter);
+    } else {
+      target[key] = value;
+    }
+  });
+
+  return target;
 };
 
 exports.callPlugin = (plugin, fn, arity, args, msg) => {
   const promise = exports.promisifyPlugin(arity, fn).apply(plugin, args);
   if (!msg) msg = 'process';
 
-  return exports.safePromise(promise, 15000, `${plugin.constructor.name} is taking long to ${msg}`);
+  const warningLogInterval = 15000;
+
+  return exports.safePromise(promise, warningLogInterval,
+    `${plugin.constructor.name} is taking too long to ${msg}`
+  );
 };
 
 exports.asyncFilter = (arr, fn) => {
   const promises = arr.map(item => fn(item).then(result => [item, result]));
   return Promise.all(promises).then(data => {
-    const filtered = data.filter(x => x[1]).map(x => x[0]);
-    return filtered;
+    return data.filter(x => x[1]).map(x => x[0]);
   });
 };
 
 
 exports.prettify = (object) => {
-  return Object.keys(object).map(key => `${key}=${object[key]}`).join(' ');
+  return Object.entries(object).map(pair => pair.join('=')).join(' ');
 };
 
 exports.identityNode = (code, source) => {
@@ -103,87 +120,65 @@ exports.generateCompilationLog = (startTime, allAssets, generatedFiles, disposed
           compiled.push(sourceName);
         }
       }
-      if (!isChanged && dgen.indexOf(generatedFile) >= 0) isChanged = true;
+      if (!isChanged && dgen.includes(generatedFile)) isChanged = true;
     });
     if (isChanged) {
       generated.push(getName(generatedFile));
       cachedCount += len - locallyCompiledCount;
     }
   });
-  const compiledCount = compiled.length;
-  const copiedCount = copied.length;
-  const disposedCount = disposedFiles.sourcePaths.length;
+  const disposed = disposedFiles.sourcePaths;
   const generatedLog = (() => {
     switch (generated.length) {
-      case 0:
-        return '';
-      case 1:
-        return ' into ' + generated[0];
-      default:
-        return ' into ' + generated.length + ' files';
+      case 0: return '';
+      case 1: return ` into ${generated}`;
     }
+    return ` into ${generated.length} files`;
   })();
   const compiledLog = (() => {
-    switch (compiledCount) {
+    switch (compiled.length) {
       case 0:
-        switch (disposedCount) {
-          case 0:
-            return '';
-          case 1:
-            return 'removed ' + disposedFiles.sourcePaths[0];
-          default:
-            return 'removed ' + disposedCount;
+        switch (disposed.length) {
+          case 0: return '';
+          case 1: return `removed ${disposed}`;
         }
+        return `removed ${disposed.length}`;
       case 1:
-        return 'compiled ' + compiled[0];
-      default:
-        return 'compiled ' + compiledCount;
+        return `compiled ${compiled}`;
     }
+    return `compiled ${compiled.length}`;
   })();
   const cachedLog = (() => {
-    switch (cachedCount) {
+    if (cachedCount === 0) return compiled.length <= 1 ? '' : ' files';
+
+    switch (compiled.length) {
       case 0:
-        if (compiledCount <= 1) {
-          return '';
-        } else {
-          return ' files';
-        }
-      default:
-        switch (compiledCount) {
-          case 0:
-            const noun = generated.length > 1 ? '' : ' files';
-            return ' and wrote ' + cachedCount + ' cached' + noun;
-          case 1:
-            const cachedCountName = 'file' + (cachedCount === 1 ? '' : 's');
-            return ' and ' + cachedCount + ' cached ' + cachedCountName;
-          default:
-            return ' files and ' + cachedCount + ' cached';
-        }
+        const noun = generated.length > 1 ? '' : ' files';
+        return ` and wrote ${cachedCount} cached${noun}`;
+      case 1:
+        const cachedCountName = `file${cachedCount === 1 ? '' : 's'}`;
+        return ` and ${cachedCount} cached ${cachedCountName}`;
     }
+    return ` files and ${cachedCount} cached`;
   })();
   const nonAssetsLog = compiledLog + cachedLog + generatedLog;
-  const sep = nonAssetsLog && copiedCount !== 0 ? ', ' : '';
+  const sep = nonAssetsLog && copied.length ? ', ' : '';
   const assetsLog = (() => {
-    switch (copiedCount) {
-      case 0:
-        return '';
-      case 1:
-        return 'copied ' + copied[0];
-      default:
-        if (compiled.length === 0) {
-          return 'copied ' + copiedCount + ' files';
-        } else {
-          return 'copied ' + copiedCount;
-        }
+    switch (copied.length) {
+      case 0: return '';
+      case 1: return `copied ${copied}`;
     }
+    return compiled.length ?
+      `copied ${copied.length}` :
+      `copied ${copied.length} files`;
   })();
   const main = nonAssetsLog + sep + assetsLog;
   const diff = Date.now() - startTime;
   const oneSecond = 1000;
   const diffText = diff > oneSecond ?
-    +(diff / oneSecond).toFixed(1) + ' sec' :
-    diff + 'ms';
-  return (main ? main : 'compiled') + ' in ' + diffText;
+    `${(diff / oneSecond).toFixed(1)} sec` :
+    `${diff} ms`;
+  return `${main || 'compiled'} in ${diffText}`;
 };
 
 const animationLogInterval = 4000;
@@ -209,3 +204,13 @@ exports.getCompilationProgress = (timePassed, logger) => {
   return () => clearTimeout(timeout);
 };
 
+const deepFreeze = exports.deepFreeze = (object, except) => {
+  Object.entries(Object.freeze(object))
+    .filter(entry => {
+      const key = entry[0];
+      if (except && except.includes(key)) return false;
+      return !Object.isFrozen(entry[1]);
+    })
+    .forEach(entry => deepFreeze(entry[1], except));
+  return object;
+};

--- a/lib/hmr.js
+++ b/lib/hmr.js
@@ -3,7 +3,7 @@
 const sysPath = require('./path');
 const logger = require('loggy');
 
-const isEnabled = config => config.hot && config.env.indexOf('production') === -1;
+const isEnabled = config => config.hot && !config.env.includes('production');
 
 const checkAutoReload = (cfg, plugins) => {
   const hasAutoReload = plugins.compilers.find(compiler => compiler.brunchPluginName === 'auto-reload-brunch');
@@ -15,8 +15,8 @@ const checkAutoReload = (cfg, plugins) => {
 };
 
 const generate = (generateModuleFiles, nonModuleFiles, processor, deppack, definition, path, root) => {
-  const hmrFile = nonModuleFiles.find(x => x.path.indexOf(sysPath.join('hmr-brunch', 'runtime.js')) !== -1);
-  nonModuleFiles = nonModuleFiles.filter(f => f !== hmrFile);
+  const hmrPath = sysPath.join('hmr-brunch', 'runtime.js');
+  const hmrFile = nonModuleFiles.find(f => f.path.includes(hmrPath));
 
   if (hmrFile) {
     processor(hmrFile);
@@ -26,15 +26,15 @@ const generate = (generateModuleFiles, nonModuleFiles, processor, deppack, defin
 
   root.add(definition);
 
-  const depGraph = deppack.graph();
-  root.add(`require.hmr(${JSON.stringify(depGraph)}, function(require) {\n`);
+  const depGraph = JSON.stringify(deppack.graph());
+  root.add(`require.hmr(${depGraph}, function(require) {\n`);
 
   generateModuleFiles();
 
   root.add('});');
   root.add('// hmr end');
 
-  nonModuleFiles.forEach(processor);
+  nonModuleFiles.filter(f => f !== hmrFile).forEach(processor);
 };
 
 module.exports = {isEnabled, checkAutoReload, generate};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 'use strict';
+require('./polyfills');
 const loggy = require('loggy');
 const initSkeleton = require('init-skeleton').init;
 const hasDebug = obj => {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -21,17 +21,18 @@ const getModuleWrapper = (type, nameCleaner, wrapper) => {
     debug(`Wrapping ${moduleName} @ ${type}`);
 
     // Wrap in common.js require definition.
-    if (type === 'commonjs') {
-      return {
-        prefix: 'require.register(' + path + ', function(exports, require, module) {\n',
-        suffix: '});\n\n'
-      };
-    } else if (type === 'amd') {
-      return {
-        data: data.replace(amdRe, match => '' + match + path + ', ')
-      };
-    } else if (type === 'function') {
-      return wrapper(moduleName, data);
+    switch (type) {
+      case 'commonjs':
+        return {
+          prefix: `require.register(${path}, function(exports, require, module) {\n`,
+          suffix: '});\n\n'
+        };
+      case 'amd':
+        return {
+          data: data.replace(amdRe, match => `${match}${path}, `)
+        };
+      case 'function':
+        return wrapper(moduleName, data);
     }
   };
 };
@@ -43,17 +44,13 @@ exports.normalizeWrapper = (typeOrFunction, nameCleaner) => {
     case 'amd':
       return getModuleWrapper('amd', nameCleaner);
     case false:
-      return (path, data) => {
-        return data;
-      };
-    default:
-      if (typeof typeOrFunction === 'function') {
-        return getModuleWrapper('function', nameCleaner, typeOrFunction);
-      } else {
-        throw new Error('config.modules.wrapper should be a ' +
-          'function or one of: "commonjs", "amd", false');
-      }
+      return (path, data) => data;
   }
+  if (typeof typeOrFunction === 'function') {
+    return getModuleWrapper('function', nameCleaner, typeOrFunction);
+  }
+  throw new Error('config.modules.wrapper should be a ' +
+    'function or one of: "commonjs", "amd", false');
 };
 
 exports.normalizeDefinition = typeOrFunction => {
@@ -63,12 +60,10 @@ exports.normalizeDefinition = typeOrFunction => {
     case 'amd':
     case false:
       return () => '';
-    default:
-      if (typeof typeOrFunction === 'function') {
-        return typeOrFunction;
-      } else {
-        throw new Error('config.modules.definition should be a ' +
-          'function or one of: "commonjs", false');
-      }
   }
+  if (typeof typeOrFunction === 'function') {
+    return typeOrFunction;
+  }
+  throw new Error('config.modules.definition should be a ' +
+    'function or one of: "commonjs", false');
 };

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,23 +1,16 @@
 'use strict';
 const sysPath = require('path');
 
-const isAbsolute = sysPath.isAbsolute;
-const basename = sysPath.basename;
-const sep = sysPath.sep;
+exports.isAbsolute = sysPath.isAbsolute;
+exports.basename = sysPath.basename;
+exports.sep = sysPath.sep;
 
-const slashes = x => x.split('\\').join('/');
-const unslashes = x => x.split('/').join(sep);
+exports.slashes = path => path.split('\\').join('/');
+exports.unslashes = path => path.split('/').join(exports.sep);
 
-const _wrap = fn => {
-  return function() {
-    return slashes(fn.apply(sysPath, arguments));
+['normalize', 'relative', 'resolve', 'join', 'dirname'].forEach(key => {
+  const fn = sysPath[key];
+  exports[key] = function() {
+    return exports.slashes(fn.apply(sysPath, arguments));
   };
-};
-
-const normalize = _wrap(sysPath.normalize);
-const relative = _wrap(sysPath.relative);
-const resolve = _wrap(sysPath.resolve);
-const join = _wrap(sysPath.join);
-const dirname = _wrap(sysPath.dirname);
-
-module.exports = {basename, dirname, sep, isAbsolute, slashes, unslashes, relative, join, resolve, normalize};
+});

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -3,22 +3,29 @@ const sysPath = require('./path');
 const debug = require('debug')('brunch:plugins');
 const logger = require('loggy');
 const speed = require('since-app-start');
+const flatten = require('./helpers').flatten;
 
-const slice = [].slice;
-const brunchPluginPattern = 'brunch'; // To filter brunch plugins.
+const isBrunchPlugin = dep => dep.name.includes('brunch');
 
-// Generate function that will check if object has property and it is a fn.
-// Returns Function.
-const propIsFunction = prop => obj => typeof obj[prop] === 'function';
+const requireModule = dep => {
+  const plugin = require(dep.path);
+  speed.profile(`Loaded plugin ${dep.name}`);
+  plugin.brunchPluginName = dep.name;
+  return plugin;
+};
 
-const getPlugins = (packages, config) => {
-  return packages
-  .filter(plugin => plugin && plugin.prototype && plugin.prototype.brunchPlugin)
-  .map(plugin => {
-    const instance = new plugin(config);
-    instance.brunchPluginName = plugin.brunchPluginName;
-    return instance;
-  });
+const pluginReducer = (plugins, dep) => {
+  try {
+    plugins.push(requireModule(dep));
+  } catch (error) {
+    if (dep.isMain) {
+      throw new Error('You probably need to execute `npm install` ' +
+        `to install brunch plugins. ${error}`);
+    } else {
+      logger.warn(`Loading of ${dep.name} failed due to`, error);
+    }
+  }
+  return plugins;
 };
 
 /* Get paths to files that plugins include. E.g. handlebars-brunch includes
@@ -28,87 +35,62 @@ const getPlugins = (packages, config) => {
  *
  * Returns Array of Strings.
  */
-const getPluginIncludes = plugins => {
-  const getValue = (thing, context) => {
-    if (context === undefined) context = this;
-    return typeof thing === 'function' ? thing.call(context) : thing;
-  };
-  const ensureArray = object => Array.isArray(object) ? object : [object];
-  return plugins
-  .map(plugin => getValue(plugin.include, plugin))
-  .filter(paths => paths)
-  .reduce((acc, elem) => { return acc.concat(ensureArray(elem)); }, []);
+const includeReducer = (paths, plugin) => {
+  if (!('include' in plugin)) return paths;
+  const include = plugin.include;
+  return paths.concat(typeof include === 'function' ?
+    include.call(plugin) :
+    include);
 };
 
-const requireModule = (depPath, dependencyName) => {
-  const plugin = require(depPath);
-  speed.profile('Loaded plugin ' + dependencyName);
-  plugin.brunchPluginName = dependencyName;
-  return plugin;
-};
-
-const loadPackages = (rootPath) => {
+const loadPackages = rootPath => {
   speed.profile('Loading plugins');
   rootPath = sysPath.resolve(rootPath);
-  const nodeModules = rootPath + '/node_modules';
-  let json;
+
   try {
-    const packagePath = sysPath.join(rootPath, 'package.json');
-    delete require.cache[require.resolve(packagePath)];
-    json = require(packagePath);
+    const pkgPath = sysPath.join(rootPath, 'package.json');
+    delete require.cache[require.resolve(pkgPath)];
+    var pkg = require(pkgPath);
   } catch (err) {
     throw new Error('Current directory is not brunch application root path, ' +
       `as it does not contain package.json (${err})`);
   }
 
-  // Also need to test if `brunch-plugin` is in dep’s package.json.
-  const loadDeps = (prop, isDev) => {
-    return prop.filter(dependency => {
-      return dependency !== brunchPluginPattern &&
-        dependency.indexOf(brunchPluginPattern) !== -1;
-    }).map(dependency => {
-      const depPath = nodeModules + '/' + dependency;
-      if (isDev) {
-        try {
-          return requireModule(depPath, dependency, true);
-        } catch (error) {
-          logger.warn(`Loading of ${dependency} failed due to`, error);
-          return null;
-        }
+  const uniqueDeps = deps => {
+    const all = deps.map(obj => obj ? Object.keys(obj) : []);
+    const main = all.shift();
+    const other = flatten(all).reduce((other, name) => {
+      if (main.includes(name)) {
+        logger.warn(`You have declared ${name} in package.json more than once`);
       } else {
-        try {
-          return requireModule(depPath, dependency);
-        } catch (error) {
-          throw new Error('You probably need to execute `npm install` ' +
-            'to install brunch plugins. ' + error);
-        }
+        other.push({name, isMain: false});
       }
+      return other;
+    }, []);
+
+    return main.map(name => {
+      return {name, isMain: true};
+    }).concat(other).map(dep => {
+      dep.path = `${rootPath}/node_modules/${dep.name}`;
+      return dep;
     });
   };
 
-  const uniqueDeps = function(/*mainDeps, ...otherDeps*/) {
-    return slice.call(arguments, 0).map(deps => {
-      return Object.keys(deps || {});
-    }).map((dep, index, deps) => {
-      if (index === 0) { return dep; }
-      // return for mainDeps; filter otherDeps for finding plugins intersection with mainDeps.
-      return dep.filter((dependency) => {
-        const depUnique = deps[0].indexOf(dependency) === -1;
-        if (!depUnique) {
-          logger.warn(`You have declared ${dependency} in both dependencies and devDependencies`);
-        }
-        return depUnique;
-      });
-    });
-  };
+  return uniqueDeps([
+    pkg.dependencies,
+    pkg.devDependencies,
+    pkg.optionalDependencies
+  ]).filter(isBrunchPlugin).reduce(pluginReducer, []);
+};
 
-  return uniqueDeps(
-    json.dependencies,
-    json.devDependencies,
-    json.optionalDependencies
-  ).map((dependencies, index) => {
-    return loadDeps(dependencies, index !== 0);
-  }).reduce((acc, elem) => { return acc.concat(elem); }, []);
+const getPlugins = (packages, config) => {
+  return packages
+  .filter(plugin => plugin && plugin.prototype && plugin.prototype.brunchPlugin)
+  .map(plugin => {
+    const instance = new plugin(config);
+    instance.brunchPluginName = plugin.brunchPluginName;
+    return instance;
+  });
 };
 
 /* Load brunch plugins, group them and initialise file watcher.
@@ -124,21 +106,18 @@ exports.init = (config, onCompile) => {
   speed.profile('Loaded config');
   logger.notifications = config.notifications;
   logger.notificationsTitle = config.notificationsTitle;
-  const black = config.plugins.off;
-  const white = config.plugins.only;
-  const packages = loadPackages('.').filter(arg => {
-    const brunchPluginName = arg.brunchPluginName;
-    if (black.length && black.indexOf(brunchPluginName) >= 0) {
-      return false;
-    } else if (white.length && white.indexOf(brunchPluginName) === -1) {
-      return false;
-    } else {
-      return true;
-    }
+  const on = config.plugins.on;
+  const off = config.plugins.off;
+  const only = config.plugins.only;
+
+  const packages = loadPackages('.').filter(plugin => {
+    const name = plugin.brunchPluginName;
+    if (off.includes(name)) return false;
+    if (only.length && !only.includes(name)) return false;
+    return true;
   });
-  const unfiltered = getPlugins(packages, config);
-  const alwaysP = config.plugins.on;
-  const plugins = unfiltered.filter(plugin => {
+
+  const plugins = getPlugins(packages, config).filter(plugin => {
 
     if (plugin.compileStatic && !plugin.staticTargetExtension) {
       logger.warn(`${plugin.brunchPluginName} does not declare target extension for static files, skipping.`);
@@ -151,7 +130,7 @@ exports.init = (config, onCompile) => {
     }
 
     // Does the user's config say this plugin should definitely be used?
-    if (alwaysP.length && alwaysP.indexOf(plugin.brunchPluginName) >= 0) {
+    if (on.includes(plugin.brunchPluginName)) {
       return true;
     }
 
@@ -167,28 +146,33 @@ exports.init = (config, onCompile) => {
 
     // Finally, is it meant for either any environment or
     // an active environment?
-    return env === '*' || config.env.indexOf(env) >= 0;
+    return env === '*' || config.env.includes(env);
   });
-  debug('Loaded plugins: ' + (plugins.map(plugin => {
-    return plugin.brunchPluginName;
-  }).join(', ')));
+
+  debug('Loaded plugins: ' +
+    plugins.map(plugin => plugin.brunchPluginName).join(', ')
+  );
+
+  const respondTo = key => plugins.filter(plugin => {
+    return typeof plugin[key] === 'function';
+  });
 
   // Get compilation methods.
-  const compilers = plugins.filter(propIsFunction('compile'));
-  const staticCompilers = plugins.filter(propIsFunction('compileStatic'));
-  const linters = plugins.filter(propIsFunction('lint'));
-  const optimizers = plugins.filter(propIsFunction('optimize'));
-  const teardowners = plugins.filter(propIsFunction('teardown'));
+  const compilers = respondTo('compile');
+  const staticCompilers = respondTo('compileStatic');
+  const linters = respondTo('lint');
+  const optimizers = respondTo('optimize');
+  const teardowners = respondTo('teardown');
 
   const preCompilers = () => {
     // Get plugin preCompile callbacks.
-    const preCompilerPromises = plugins.filter(propIsFunction('preCompile')).map(plugin => {
+    const preCompilerPromises = respondTo('preCompile').map(plugin => {
       return new Promise((resolve, reject) => {
         if (plugin.preCompile.length === 1) {
           plugin.preCompile(resolve);
         } else {
           const ret = plugin.preCompile();
-          if (ret && ret.then) {
+          if (ret && typeof ret.then === 'function') {
             ret.then(resolve, reject);
           } else {
             resolve();
@@ -205,7 +189,7 @@ exports.init = (config, onCompile) => {
           config.hooks.preCompile(resolve);
         } else {
           const ret = config.hooks.preCompile();
-          if (ret && ret.then) {
+          if (ret && typeof ret.then === 'function') {
             ret.then(resolve, reject);
           } else {
             resolve();
@@ -217,12 +201,8 @@ exports.init = (config, onCompile) => {
   };
 
   // Get plugin onCompile callbacks.
-  const callbacks = plugins.filter(propIsFunction('onCompile'))
-  .map(plugin => {
-    return function() {
-      const args = slice.call(arguments, 0);
-      return plugin.onCompile.apply(plugin, args);
-    };
+  const callbacks = respondTo('onCompile').map(plugin => function() {
+    return plugin.onCompile.apply(plugin, arguments);
   });
 
   // Add onCompile callback from config.hooks.
@@ -239,7 +219,9 @@ exports.init = (config, onCompile) => {
     teardowners.forEach(plugin => plugin.teardown());
   };
   speed.profile('Loaded plugins');
-  const includes = getPluginIncludes(plugins);
+
+  const includes = plugins.reduce(includeReducer, []);
+
   return Promise.resolve({
     compilers, staticCompilers, linters, includes, teardownBrunch, optimizers,
     preCompilers, callCompileCallbacks
@@ -253,28 +235,20 @@ exports.init = (config, onCompile) => {
  *
  * Returns Function.
  */
-
-const _patterns = {};
-const _neverMatchRe = /$0^/;
-const _getPattern = (ext, pattern) => {
-  if (pattern) {
-    return pattern;
-  } else if (ext) {
-    const re = _patterns[ext] || (_patterns[ext] = new RegExp('\\.' + ext + '$'));
-    return re;
-  } else {
-    return _neverMatchRe;
-  }
-};
-
 exports.patternFor = (plugin, isStatic) => {
-  if (isStatic) {
-    return _getPattern(plugin.staticExtension || plugin.extension, plugin.staticPattern || plugin.pattern);
-  } else {
-    return _getPattern(plugin.extension, plugin.pattern);
-  }
+  const pattern = isStatic ?
+    plugin.staticPattern || plugin.pattern :
+    plugin.pattern;
+  if (pattern) return pattern;
+
+  const ext = isStatic ?
+    plugin.staticExtension || plugin.extension :
+    plugin.extension;
+  if (ext) return new RegExp(`\\.${ext}$`);
+
+  return /.^/; // never matches
 };
 
-exports.isPluginFor = (path, isStatic) => {
-  return plugin => exports.patternFor(plugin, isStatic).test(path);
+exports.isPluginFor = (path, isStatic) => plugin => {
+  return exports.patternFor(plugin, isStatic).test(path);
 };

--- a/lib/polyfills.js
+++ b/lib/polyfills.js
@@ -1,0 +1,31 @@
+'use strict';
+/* eslint-disable no-extend-native */
+
+const dontEnum = fn => {
+  return { value: fn, writable: true, configurable: true };
+};
+
+const values = object => {
+  return Object.keys(object).map(key => object[key]);
+};
+
+const entries = object => {
+  return Object.keys(object).map(key => [key, object[key]]);
+};
+
+if (!Object.values || !Object.entries) {
+  Object.defineProperties(Object, {
+    values: dontEnum(values),
+    entries: dontEnum(entries)
+  });
+}
+
+if (![].includes) {
+  const includes = function(search) {
+    const array = arguments.length > 1 ? [].slice.call(this, arguments[1]) : this;
+    const is = Number.isNaN(search) ? Number.isNaN : (el => el === search);
+    return [].some.call(array, is);
+  };
+  Object.defineProperty(Array.prototype, 'includes', dontEnum(includes));
+  Array.prototype[Symbol.unscopables].includes = true;
+}

--- a/lib/run-cli.js
+++ b/lib/run-cli.js
@@ -1,3 +1,2 @@
 'use strict';
 require('./cli').run();
-

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -34,7 +34,7 @@ const filterNonExistentPaths = (paths) => {
 };
 
 const isSymlink = (path) => {
-  return fslstat(path).then((stat => stat.isSymbolicLink()), () => false);
+  return fslstat(path).then(stat => stat.isSymbolicLink(), () => false);
 };
 
 // Filter paths that exist and watch them with `chokidar` package.
@@ -55,11 +55,11 @@ const checkProjectDependencies = cfg => {
   const scopeList = isProduction ? ['dependencies'] : ['dependencies', 'devDependencies'];
   return checkDeps({packageDir: rootPath, scopeList}).then(out => {
     if (out.depsWereOk === false) {
-      const pkgs = out.error.filter(x => x.indexOf(':') !== -1).map(x => x.split(':')[0]);
+      const pkgs = out.error.filter(x => x.includes(':')).map(x => x.split(':', 1)[0]);
       // filter out symlinked packages
       const isNotSymlink = pkg => isSymlink(pkgPath(pkg)).then(x => !x);
       return helpers.asyncFilter(pkgs, isNotSymlink).then(unmetPkgs => {
-        if (unmetPkgs.length > 0) {
+        if (unmetPkgs.length) {
           logger.info(`Using outdated versions of ${unmetPkgs.join(', ')}, trying to update to match package.json versions`);
           return application.install(rootPath, 'npm', isProduction).then(() => cfg, () => cfg);
         }
@@ -104,7 +104,7 @@ class BrunchWatcher {
     setDefaultJobsCount(options);
 
     application.loadConfig(persistent, options).then(setProp(this, 'config'))
-      .then(cfg => checkProjectDependencies(cfg))
+      .then(checkProjectDependencies)
       .then(cfg => {
         if (options.jobs && options.jobs > 1) {
           workers.init(persistent, options, cfg);
@@ -174,9 +174,7 @@ class BrunchWatcher {
       if (this.nothingToCompileTimer) {
         clearTimeout(this.nothingToCompileTimer);
       }
-      this.nothingToCompileTimer = setTimeout(() => {
-        checkNothingToCompile();
-      }, emptyFileListInterval);
+      this.nothingToCompileTimer = setTimeout(checkNothingToCompile, emptyFileListInterval);
     }
 
     if (cfg.persistent && cfg.stdin) {
@@ -334,7 +332,7 @@ class BrunchWatcher {
     }, error => {
       fileList.emit('bundled');
       if (!Array.isArray(error)) error = [error];
-      const canTryRecover = error.find(err => err.toString().indexOf('run `npm install`') !== -1);
+      const canTryRecover = error.find(err => err.toString().includes('run `npm install`'));
 
       error.forEach(subError => logger.error(subError));
 
@@ -400,7 +398,7 @@ class BrunchWatcher {
 }
 
 const watch = (persistent, path, options, callback) => {
-  if (!callback) callback = Function.prototype;
+  if (!callback) callback = () => {};
 
   // If path isn't provided (by CLI).
   if (path) {

--- a/lib/workers/job-processor.js
+++ b/lib/workers/job-processor.js
@@ -2,13 +2,13 @@
 const loadConfigWorker = require('../config').loadConfigWorker;
 const initPlugins = require('../plugins').init;
 
-let cfg, plugs; // eslint-disable-line prefer-const
+let cfg, plugins; // eslint-disable-line prefer-const
 
 const options = JSON.parse(process.env.BRUNCH_OPTIONS);
 loadConfigWorker(false, options).then(_cfg => {
   cfg = _cfg;
   return initPlugins(cfg, () => {}).then(_plugins => {
-    plugs = _plugins;
+    plugins = _plugins;
     process.send('ready');
   });
 });
@@ -23,7 +23,7 @@ const processMsg = (msg) => {
   const data = msg.data;
 
   const job = jobs[type];
-  const hash = job.deserialize({ plugins: plugs }, data.hash);
+  const hash = job.deserialize({plugins}, data.hash);
   return job.work(hash);
 };
 

--- a/lib/workers/manager.js
+++ b/lib/workers/manager.js
@@ -1,5 +1,5 @@
 'use strict';
-const child_process = require('child_process'); // eslint-disable-line camelcase
+const fork = require('child_process').fork;
 const EventEmitter = require('events');
 const debug = require('debug')('brunch:workers');
 
@@ -48,7 +48,7 @@ class WorkerManager {
     // pass parsed options to not make each worker parse the options
     const workerEnv = {BRUNCH_OPTIONS: JSON.stringify(options)};
     const env = Object.assign({}, process.env, workerEnv);
-    const worker = child_process.fork(workerFile, {env}); // eslint-disable-line camelcase
+    const worker = fork(workerFile, {env});
     const events = this.events;
     let idx;
     worker.on('message', (msg) => {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "http://brunch.io/",
   "author": "Brunch team (http://brunch.io)",
-  "repository": "https://github.com/brunch/brunch.git",
+  "repository": "brunch/brunch",
   "bugs": "http://github.com/brunch/brunch/issues",
   "license": "MIT",
   "main": "./lib/index",
@@ -38,7 +38,8 @@
     "brunch": "./bin/brunch"
   },
   "scripts": {
-    "test": "eslint lib test && ava -s",
+    "lint": "eslint lib test",
+    "test": "npm run lint && ava -s",
     "test:coverage": "nyc ava -s && nyc report --reporter=html"
   },
   "engines": {
@@ -54,7 +55,6 @@
     "commander": "~2.9.0",
     "commonjs-require-definition": "~0.5.0",
     "debug": "~2.2.0",
-    "deep-assign": "^2.0.0",
     "deppack": "~0.6.0",
     "fcache": "~0.1.0",
     "init-skeleton": "~0.9.0",


### PR DESCRIPTION
1. removed `deep-assign` dependency, extracted reusable `customDeepAssign` to helpers; added `filter` as third attribute
2. added lightweight `Array#includes`, `Object.values` and `Object.entries` shims
3. moved `deepFreeze` to helpers; added optional second param
4. refactored `plugins.js`: more cohesion, pure functions, less additional params and index checking
5. replaced `Promise.resolve` with `return` and `Promise.reject` with `throw` in `Promise#then`
6. added more template strings in more places
7. various code style and type coercion fixes