### PR TITLE
Allow disabling bower

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,6 @@
 require('./polyfills');
 require('coffee-script').register();
 
-const fs = require('fs');
 const sysPath = require('./path');
 const exec = require('child_process').exec;
 const logger = require('loggy');
@@ -68,6 +67,10 @@ const configBaseSchema = v.object({
     static: v.array(v.string).default([]),
     compilers: v.array(v.string).default([]),
     detectProcess: v.bool.default(true)
+  }).default({}),
+
+  bower: v.object({
+    enabled: v.bool.default(true)
   }).default({}),
 
   plugins: v.object({
@@ -146,7 +149,9 @@ const productionOverrideSchema = v.merge(
 const configSchema = v.merge(
   configBaseSchema,
   v.object({
-    overrides: v.objects({specifics: {production: productionOverrideSchema}}, overrideSchema).default({})
+    overrides: v.objects({
+      specifics: {production: productionOverrideSchema}
+    }, overrideSchema).default({})
   })
 );
 
@@ -467,15 +472,15 @@ const addDefaultServer = config => {
   return config;
 };
 
-const loadComponents = (config, type) => {
+const loadBower = config => {
   // Since readComponents call its callback with many arguments, we hate to wrap it manually
   return new Promise((resolve, reject) => {
-    readComponents('.', type, (err, components) => {
+    if (!config.bower.enabled) return resolve([]);
+    readComponents(config.paths.root, 'bower', (err, components) => {
       if (err) reject(err);
-      else resolve({components});
+      else resolve(components || []);
     });
-  }).then(o => {
-    const components = o.components || [];
+  }).then(components => {
     const order = components
       .sort((a, b) => {
         if (a.sortingLevel === b.sortingLevel) {
@@ -493,7 +498,7 @@ const loadComponents = (config, type) => {
     }
 
     // Returning default values
-    return {components: [], aliases: [], order: []};
+    return {components: [], order: []};
   });
 };
 
@@ -517,22 +522,19 @@ const loadNpm = config => {
 };
 
 const checkComponents = config => {
-  return new Promise(resolve => {
-    const path = sysPath.resolve(config.paths.root, 'component.json');
-    fs.exists(path, exists => {
-      if (exists) {
-        logger.warn('Detected component.json in project root. Component.json is no longer supported. You could switch to keeping dependencies in NPM (package.json), or revert to Brunch 2.2.');
-      }
-      resolve();
-    });
+  const path = sysPath.resolve(config.paths.root, 'component.json');
+  helpers.fsExists(path).then(exists => {
+    if (exists) {
+      logger.warn('Detected component.json in project root. Component.json is no longer supported. You could switch to keeping dependencies in NPM (package.json), or revert to Brunch 2.2.');
+    }
   });
 };
 
 const addPackageManagers = config => {
+  checkComponents(config);
   return Promise.all([
     loadNpm(config),
-    loadComponents(config, 'bower'),
-    checkComponents(config)
+    loadBower(config)
   ]).then(components => {
     const norm = config._normalized.packageInfo;
     norm.npm = components[0];

--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -57,35 +57,33 @@ const getDependencies = (data, path, compilerDeps, compiler) => {
 const compileStatic = (path, plugin) => {
   return readFromCache(path).then(source => {
     return processJob(CompileStaticJob, {path, source, plugin}).then(data => {
-      return Object.assign({}, data, {source});
+      return Object.assign({source}, data);
     });
   });
 };
 
-const _compileStatic = (path, source, compiler) => {
-  let compilationTime, compiled;
+const _compileStatic = (path, data, compiler) => {
   debug(`Compiling static ${path} @ ${compiler.constructor.name}`);
-  return compiler.compileStatic({path, data: source}).then(_compiled => {
-    compilationTime = Date.now();
-    compiled = _compiled && typeof _compiled === 'object' ? _compiled.data : _compiled;
-    if (compiler.getDependencies) {
-      return callPlugin(compiler, compiler.getDependencies, 2, [source, path])
-        .catch(error => prepareError('Dependency parsing', error));
-    }
-    return [];
-  }).then(dependencies => {
-    return {compiled, compilationTime, dependencies};
-  }, error => prepareError('Compiling', error));
+  return compiler.compileStatic({path, data}).then(compiled => {
+    const compilationTime = Date.now();
+    const data = compiled && typeof compiled === 'object' ? compiled.data : compiled;
+    const deps = compiler.getDependencies ?
+      callPlugin(compiler, compiler.getDependencies, 2, [data, path])
+        .catch(error => prepareError('Dependency parsing', error)) :
+      Promise.resolve([]);
+
+    return deps.then(dependencies => {
+      return {compiled: data, compilationTime, dependencies};
+    });
+  }).catch(error => prepareError('Compiling', error));
 };
 
 const compilerChain = (previousPromise, compiler) => {
   return previousPromise.then(params => {
     if (!params) return;
 
-    // const dependencies = params.dependencies;
     const compiled = params.compiled;
     const source = params.source;
-    let sourceMap = params.sourceMap;
     const path = params.path;
     debug(`Compiling ${path} @ ${compiler.constructor.name}`);
     const compilerData = compiled || source;
@@ -94,7 +92,7 @@ const compilerChain = (previousPromise, compiler) => {
     // New API: compile({data, path}, callback)
     // Old API: compile(data, path, callback)
     const compilerArgs = fn.length === 2 || fn.length === 1 ?
-      [{data: compilerData, path, map: sourceMap}] :
+      [{data: compilerData, path, map: params.sourceMap}] :
       [compilerData, path];
     return callPlugin(compiler, fn, 1, compilerArgs, `compile ${path}`)
       .then(result => {
@@ -103,7 +101,7 @@ const compilerChain = (previousPromise, compiler) => {
         const compiled = isObject ? result.data : result;
         const compilerDeps = isObject && result.dependencies;
         const jsExports = isObject && result.exports;
-        if (isObject) sourceMap = result.map;
+        const sourceMap = isObject ? result.map : params.sourceMap;
         if (compiled == null) {
           throw new Error(`Brunch SourceFile: file ${path} data is invalid`);
         }
@@ -176,7 +174,7 @@ const CompileStaticJob = {
   }
 };
 
-exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
+const pipeline = (path, linters, compilers, fileList, depCompilers) => {
   if (deppack.isNpm(path)) {
     const _path = sysPath.resolve('.', path);
     const selectedLinters = [];
@@ -207,6 +205,9 @@ exports.pipeline = (path, linters, compilers, fileList, depCompilers) => {
     .then(deppack.exploreDeps(fileList));
 };
 
-exports.CompileJob = CompileJob;
-exports.CompileStaticJob = CompileStaticJob;
-exports.compileStatic = compileStatic;
+module.exports = {
+  pipeline,
+  CompileJob,
+  CompileStaticJob,
+  compileStatic
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,8 @@
 const getBasename = require('./path').basename;
 const SourceNode = require('source-map').SourceNode;
 const promisify = require('micro-promisify');
+const fslstat = promisify(require('fs').lstat);
+const fsaccess = promisify(require('fs').access);
 const logger = require('loggy');
 
 const isWindows = require('os').platform() === 'win32';
@@ -211,6 +213,14 @@ const deepFreeze = (object, except) => {
   return object;
 };
 
+const fsExists = path => {
+  return fsaccess(path).then(() => true, () => false);
+};
+
+const isSymlink = path => {
+  return fslstat(path).then(stat => stat.isSymbolicLink(), () => false);
+};
+
 module.exports = {
   isWindows,
   flatten,
@@ -224,5 +234,7 @@ module.exports = {
   formatError,
   generateCompilationLog,
   getCompilationProgress,
-  deepFreeze
+  deepFreeze,
+  fsExists,
+  isSymlink
 };

--- a/lib/polyfills.js
+++ b/lib/polyfills.js
@@ -5,15 +5,15 @@ const dontEnum = fn => {
   return {value: fn, writable: true, configurable: true};
 };
 
-const values = object => {
-  return Object.keys(object).map(key => object[key]);
-};
+if (!Object.values) {
+  const values = object => {
+    return Object.keys(object).map(key => object[key]);
+  };
 
-const entries = object => {
-  return Object.keys(object).map(key => [key, object[key]]);
-};
+  const entries = object => {
+    return Object.keys(object).map(key => [key, object[key]]);
+  };
 
-if (!Object.values || !Object.entries) {
   Object.defineProperties(Object, {
     values: dontEnum(values),
     entries: dontEnum(entries)
@@ -24,8 +24,10 @@ if (![].includes) {
   const includes = function(search) {
     const array = arguments.length > 1 ? [].slice.call(this, arguments[1]) : this;
     const is = Number.isNaN(search) ? Number.isNaN : el => el === search;
-    return [].some.call(array, is);
+    return [].findIndex.call(array, is) !== -1;
   };
   Object.defineProperty(Array.prototype, 'includes', dontEnum(includes));
-  Array.prototype[Symbol.unscopables].includes = true;
 }
+
+// https://bugs.chromium.org/p/v8/issues/detail?id=5059
+[][Symbol.unscopables].includes = true;

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -7,10 +7,7 @@ const debug = require('debug')('brunch:watch');
 const speed = require('since-app-start');
 const serveBrunch = require('serve-brunch');
 const checkDeps = require('check-dependencies');
-const promisify = require('micro-promisify');
-const fslstat = promisify(require('fs').lstat);
-const fsaccess = promisify(require('fs').access);
-const cpus = require('os').cpus();
+const cpus = require('os').cpus().length;
 const deppack = require('deppack');
 
 const workers = require('./workers'); // close, init
@@ -20,21 +17,13 @@ const plugins = require('./plugins'); // init, isPluginFor
 const helpers = require('./helpers'); // asyncFilter, flatten, generateCompilationLog, getCompilationProgress
 const checkHmrAutoReload = require('./hmr').checkAutoReload;
 
-const fsExists = path => {
-  return fsaccess(path).then(() => true, () => false);
-};
-
 const emptyFileListInterval = 1000;
 
 const filterNonExistentPaths = paths => {
-  return Promise.all(paths.map(fsExists)).then(values => {
+  return Promise.all(paths.map(helpers.fsExists)).then(values => {
     const watchedFiles = paths.filter((path, index) => values[index]);
     return watchedFiles;
   });
-};
-
-const isSymlink = path => {
-  return fslstat(path).then(stat => stat.isSymbolicLink(), () => false);
 };
 
 // Filter paths that exist and watch them with `chokidar` package.
@@ -46,31 +35,23 @@ const getWatchedPaths = config => {
   return filterNonExistentPaths(watched);
 };
 
-const setProp = (obj, name) => result => {
-  obj[name] = result;
-  return result;
-};
-
-const checkProjectDependencies = cfg => {
-  const rootPath = cfg.paths.root;
-  const isProduction = cfg._normalized.isProduction;
-  const pkgPath = pkg => sysPath.join(rootPath, 'node_modules', pkg);
+const checkProjectDependencies = config => {
+  const packageDir = config.paths.root;
+  const isProduction = config._normalized.isProduction;
   const scopeList = isProduction ? ['dependencies'] : ['dependencies', 'devDependencies'];
-  return checkDeps({packageDir: rootPath, scopeList}).then(out => {
-    if (out.depsWereOk === false) {
-      const pkgs = out.error.filter(x => x.includes(':')).map(x => x.split(':', 1)[0]);
-      // filter out symlinked packages
-      const isNotSymlink = pkg => isSymlink(pkgPath(pkg)).then(x => !x);
-      return helpers.asyncFilter(pkgs, isNotSymlink).then(unmetPkgs => {
-        if (unmetPkgs.length) {
-          logger.info(`Using outdated versions of ${unmetPkgs.join(', ')}, trying to update to match package.json versions`);
-          return application.install(rootPath, 'npm', isProduction).then(() => cfg, () => cfg);
-        }
-        return cfg;
-      });
-    }
-
-    return cfg;
+  return checkDeps({packageDir, scopeList}).then(out => {
+    if (out.depsWereOk) return;
+    const pkgs = out.error.filter(x => x.includes(':')).map(x => x.split(':', 1)[0]);
+    throw pkgs;
+  }).catch(pkgs => {
+    // filter out symlinked packages
+    const pkgPath = pkg => sysPath.join(packageDir, 'node_modules', pkg);
+    const isNotSymlink = pkg => helpers.isSymlink(pkgPath(pkg)).then(x => !x);
+    return helpers.asyncFilter(pkgs, isNotSymlink).then(unmetPkgs => {
+      if (!unmetPkgs.length) return;
+      logger.info(`Using outdated versions of ${unmetPkgs.join(', ')}, trying to update to match package.json versions`);
+      return application.install(packageDir, 'npm', isProduction);
+    });
   });
 };
 
@@ -80,7 +61,7 @@ const setDefaultJobsCount = options => {
   if (!options.jobs && !envy) return;
   if (options.jobs === true) options.jobs = undefined;
   // Mitigates Intel Hyperthreading.
-  const str = options.jobs || envy || cpus.length / 2;
+  const str = options.jobs || envy || cpus / 2;
   const parsed = parseInt(str);
   const jobs = isNaN(parsed) || parsed < 1 || parsed > MAX_JOBS ? 1 : parsed;
   options.jobs = jobs;
@@ -106,28 +87,34 @@ class BrunchWatcher {
     this._onReload = options._onReload;
     setDefaultJobsCount(options);
 
-    application.loadConfig(persistent, options).then(setProp(this, 'config'))
-      .then(checkProjectDependencies)
+    application.loadConfig(persistent, options)
       .then(cfg => {
-        if (options.jobs && options.jobs > 1) {
+        this.config = cfg;
+        return checkProjectDependencies(cfg)
+          .then(() => cfg, () => cfg);
+      })
+      .then(cfg => {
+        if (options.jobs > 1) {
           workers.init(persistent, options, cfg);
         }
         this.fileList = new fsUtils.FileList(cfg, this);
         return Promise.all([
-          getWatchedPaths(cfg).then(setProp(this, '_watchedPaths')),
-          serveBrunch.serve(cfg.server).then(setProp(this, 'server')),
-          plugins.init(cfg, onCompile).then(setProp(this, 'plugins'))
+          getWatchedPaths(cfg),
+          serveBrunch.serve(cfg.server),
+          plugins.init(cfg, onCompile)
         ]);
       })
-      .then(() => {
+      .then(res => {
+        this._watchedPaths = res[0];
+        this.server = res[1];
+        const plugins = this.plugins = res[2];
         const cfg = this.config;
-        const plugins = this.plugins;
         deppack.setPlugins(plugins, cfg.npm.compilers);
         if (cfg.hot) {
           checkHmrAutoReload(cfg, plugins);
         }
+        this.initCompilation();
       })
-      .then(() => this.initCompilation())
       .catch(error => {
         let text = typeof error === 'string' ? error : '';
         text = error.code === 'BRSYNTAX' ? text : `Initialization error - ${text.trim()}`;


### PR DESCRIPTION
1. Removed deprecated `fs.exists`, moved fs helpers to `helpers.js`.
2. Refactored `loadComponents`.
3. `addPackageManagers` does not wait for `component.json` deprecation warning.
4. Removed `setProp` helper and refactored `checkProjectDependencies`.
5. Handled couple edge cases in polyfills.