### PR TITLE
Normalize/sanitize config.paths with trailing slashes

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -289,6 +289,18 @@ const normalizeConfig = config => {
   return config;
 };
 
+const trimTrailingSlashes = config => {
+  const trailingSlash = /\/$/;
+
+  config.paths.public = config.paths.public.replace(trailingSlash, '');
+
+  config.paths.watched.forEach((value, index) => {
+    config.paths.watched[index] = value.replace(trailingSlash, '');
+  });
+
+  return config;
+};
+
 const addDefaultServer = config => {
   if (config.server.path) return config;
   try {
@@ -461,6 +473,7 @@ const loadConfig = (persistent, options, fromWorker) => {
     .then(config => applyOverrides(config, params.env))
     .then(config => helpers.deepAssign(config, params))
     .then(normalizeConfig)
+    .then(trimTrailingSlashes)
     .then(fromWorker || addPackageManagers)
     .then(helpers.deepFreeze(dontFreeze));
 };

--- a/test/config.js
+++ b/test/config.js
@@ -31,3 +31,16 @@ test('overrides the config using the specified env', function* (t) {
   t.is(brunchConfig.paths.public, 'tmp');
   t.deepEqual(watched, ['app', 'test']);
 });
+
+test('removes trailing slash from paths', function* (t) {
+  const opts = {
+    config: path.relative(__dirname, './fixtures/config-with-trailing-slashes.js')
+  };
+
+  const brunchConfig = yield config.loadConfig(false, opts, true);
+
+  t.deepEqual(brunchConfig.paths.watched, [
+    'app/assets'
+  ]);
+  t.is(brunchConfig.paths.public, 'app/builds');
+});

--- a/test/fixtures/config-with-trailing-slashes.js
+++ b/test/fixtures/config-with-trailing-slashes.js
@@ -1,0 +1,9 @@
+module.exports = {
+  files: {},
+  paths: {
+    watched: [
+      'app/assets/',
+    ],
+    public: 'app/builds/',
+  },
+};


### PR DESCRIPTION
Our internal code expects that the `config.paths.public` and
`config.paths.watched` paths don't end with a trailing slash.

For example, in `lib/fs_utils/generate.js` line 213, we have this:

```js
const len = config.paths['public'].length + 1;
const joinKey = path.slice(len);
```

If we had a trailing slash in the end of the public path, the joinKey
might be different then what we expect.

Another example, in `lib/config.js` line 185, we have:

```js
const isTargetWatched = paths.watched.some(path => target.startsWith(`${path}/`));
```

It appends a trailing slash to the path.

***Note***

I don't think this is the best solution, but given that I'm not 100%
familiar with brunch's source code, and there may be more instances of
code that doesn't expect a trailing slash, sanitizing user input seems to be
best for now.