### PR TITLE
Remove backslash from the error string.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ exports.new = (path, options) => {
     if (oldSyntax) {
       const skeleton = opts[0];
       const path = opts[1];
-      loggy.error(`The 'brunch new ${skeleton} ${path}\' syntax is no longer supported. Use 'brunch new ${path} -s ${skeleton}'`);
+      loggy.error(`The 'brunch new ${skeleton} ${path}' syntax is no longer supported. Use 'brunch new ${path} -s ${skeleton}'`);
       return true;
     }
   };


### PR DESCRIPTION
Someone forgot to remove backslash.  https://github.com/brunch/brunch/commit/e23eb42812e2bcb299883e745cf7ac60c3fddd12

![tumblr_m3n1aa6fbw1r6w5o5o1_500](https://cloud.githubusercontent.com/assets/1521229/18671726/d788c32c-7f4d-11e6-9a99-21f88f32afc6.png)
