### PR TITLE
New plugin type: external compiler

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,6 +48,7 @@ program.command('build [path]')
   .option('-p, --production', 'same as `--env production`')
   .option('-d, --debug [pattern]', 'print verbose debug output to stdout')
   .option('-j, --jobs [num]', 'parallelize the build')
+  .option('-c, --config [path]', 'specify a path to brunch config file')
   .action(commands.build);
 
 program.command('watch [path]')
@@ -59,6 +60,7 @@ program.command('watch [path]')
   .option('-P, --port [port]', 'if `server` was given, listen on this port')
   .option('-d, --debug [pattern]', 'print verbose debug output to stdout')
   .option('-j, --jobs [num]', 'parallelize the build')
+  .option('-c, --config [path]', 'specify a path to brunch config file')
   .option('--stdin', 'listen to stdin and exit when stdin closes')
   .action(commands.watch);
 
@@ -72,9 +74,6 @@ var checkForRemovedOptions = function(args, command) {
     return valid.includes(command);
   };
   // Deprecations
-  if (hasArg(['-c', '--config'])) {
-    return '--config has been removed. Use `-e / --environment` and specify custom envorinments in config';
-  }
   if (hasArg(['-o', '--optimize'])) {
     return '--optimize has been removed. Use `-p / --production`';
   }


### PR DESCRIPTION
This is more to open a discussion.

As per [this issue](https://github.com/brunch/brunch/issues/1573), there are some plugins that behave differently from what brunch expects them to. E.g. the `elm-brunch` plugin, mentioned in the issue, runs an external `elm-make` compiler instead of compiling each file separately.

This pull request is a proof of concept of a new plugin type, external compilers. It's required for a `compileExternal` function to be defined in a plugin, just like we define `compile` for regular compiler plugins. [Here](https://github.com/stelmakh/elm-brunch) is the example of `elm-brunch` plugin utilizing this new API.