### PR TITLE
Add ability to debug using node --inspect.

### DIFF
--- a/bin/brunch
+++ b/bin/brunch
@@ -34,7 +34,7 @@ var exists = function(path) {
 
 var runSeparateWatchProcess = function(cliPath) {
   process.env.BRUNCH_FORKED_PROCESS = 'true';
-  var args = process.env.NODE_ENV === 'development' ? ['--inspect', '--debug-brk'] : process.execArgv;
+  var args = process.env.BRUNCH_DEVTOOLS ? ['--inspect', '--debug-brk'] : process.execArgv;
   var proc = childProcessFork(cliPath, process.argv.slice(2), {execArgv: args});
   proc.on('message', function(message) {
     if (message === 'reload') {

--- a/bin/brunch
+++ b/bin/brunch
@@ -34,7 +34,8 @@ var exists = function(path) {
 
 var runSeparateWatchProcess = function(cliPath) {
   process.env.BRUNCH_FORKED_PROCESS = 'true';
-  var proc = childProcessFork(cliPath, process.argv.slice(2));
+  var args = process.env.NODE_ENV === 'development' ? ['--inspect', '--debug-brk'] : process.execArgv;
+  var proc = childProcessFork(cliPath, process.argv.slice(2), {execArgv: args});
   proc.on('message', function(message) {
     if (message === 'reload') {
       proc.kill();


### PR DESCRIPTION
This PR adds ability to debug Brunch using `node --inspect --debug-brk`. Let's forget about `console.log`ing!

Now, if `NODE_ENV` environment variable is set to `development`, ` --inspect` and `--debug-brk` flags will be passed as arguments to forked process.

**For example:**

```sh
$ NODE_ENV='development' brunch watch

Debugger listening on port 9229.
Warning: This is an experimental feature and could change at any time.
To start debugging, open the following URL in Chrome:
    chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=127.0.0.1:9229/f773c7f2-7f84-4c51-8c02-fd3e230e2205
```

**In Google Chrome:**

![image](https://cloud.githubusercontent.com/assets/3459374/20830544/9c612526-b889-11e6-8205-4792a815cd4d.png)



