### PR TITLE
Fix bug: linter error message: rethrow() expects an Error object

### DIFF
--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -21,7 +21,7 @@ const lint = (file, linters) => {
     if (/^warn:\s/i.test(error)) {
       logger.warn(`Linting of ${file.path}: ${error}`);
     } else {
-      rethrow('Linting')(error);
+      rethrow('Linting')(new Error(error));
     }
   });
 };


### PR DESCRIPTION
[`rethrow('Linting')`](https://github.com/brunch/brunch/blob/2.9.1/lib/fs_utils/pipeline.js#L24) returns [a function](https://github.com/brunch/brunch/blob/2.9.1/lib/utils/error.js#L25-L27) which takes an `error` parameter and throws a new `BrunchError`.

The parameter must be an [`Error`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Error) object, because its [`message`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message) property is [accessed within the `BrunchError` constructor](https://github.com/brunch/brunch/blob/2.9.1/lib/utils/error.js#L14).

:warning: Currently, the parameter is a `string` (as can be seen [here](https://github.com/brunch/brunch/blob/2.9.1/lib/fs_utils/pipeline.js#L21) where it's tested with a regex), and so [`error.message` evaluates to `undefined`](https://github.com/brunch/brunch/blob/2.9.1/lib/utils/error.js#L14) in the `BrunchError` constructor.