### PR TITLE
Fix debug. Close #1592

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,14 +36,13 @@ exports.new = (rootPath, options) => {
 };
 
 const start = (persistent, arg2, arg3) => {
-  const watch = require('./watch');
   const isDebug = hasDebug(arg2) || hasDebug(arg3);
   if (isDebug) {
     let ns = typeof isDebug === 'string' ? isDebug : '*';
     if (ns !== 'speed') ns = `brunch:${ns}`;
     process.env.DEBUG = ns;
   }
-  return watch(persistent, arg2, arg3);
+  return require('./watch')(persistent, arg2, arg3);
 };
 
 exports.build = start.bind(null, false);


### PR DESCRIPTION
I've found the real cause of this issue. We require `watch` before we assign `process.env.DEBUG` any value, so it's `undefined` and debug messenges are not shown.

Commit that introduce the issue: https://github.com/brunch/brunch/commit/34bab856ba82ce8d3700b54bf695f2e87098171b

---

#1595 is a bad solution, so it have to be closed.