### PR TITLE
Improve error messages

### DIFF
--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -40,7 +40,8 @@ const prettify = object => {
 
 const formatError = file => {
   const error = file.error;
-  return `${error.pipelineCode || 'Processing'} of ${file.path} failed. ${error.message}`;
+  const message = error.message.trim().replace(/^/gm, '   ');
+  return `${error.pipelineCode || 'Processing'} of ${file.path} failed.\n\n${message}\n`;
 };
 
 /* compiled 4 files and 145 cached files into app.js


### PR DESCRIPTION
Before:

    $ brunch b
    29 Dec 14:22:58 - error: Compiling of app/test.js failed. SyntaxError: app/test.js: super() is only allowed in a derived constructor
      2 |   constructor() {
      3 |     this.foo = 1
    > 4 |     super()
        |     ^
      5 |   }
      6 | }
      7 |
    29 Dec 14:22:58 - error: Compiling of app/test.scss failed. Error: Invalid CSS after "  background-color": expected "}", was ": white"
            on line 3 of app/test.scss
    >>   background-color: white
       --^

    29 Dec 14:22:58 - info: compiled in 815 ms

After:

    $ brunch b
    29 Dec 14:21:48 - error: Compiling of app/test.scss failed.

       Error: Invalid CSS after "  background-color": expected "}", was ": white"
               on line 3 of app/test.scss
       >>   background-color: white
          --^

    29 Dec 14:21:48 - error: Compiling of app/test.js failed.

       SyntaxError: app/test.js: super() is only allowed in a derived constructor
         2 |   constructor() {
         3 |     this.foo = 1
       > 4 |     super()
           |     ^
         5 |   }
         6 | }
         7 |

    29 Dec 14:21:48 - info: compiled in 795 ms

![screenshot from 2016-12-29 14-15-34](https://cloud.githubusercontent.com/assets/2142817/21544783/7e2a0114-cdd2-11e6-920b-e8c41966c3ec.png)
