### PR TITLE
Do not overwrite the NODE_ENV environment variable

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -485,8 +485,8 @@ const initParams = (persistent, options) => {
     stdin: options.stdin != null,
     env: env ? env.split(',') : [],
   };
-  if (options.production == null) {
-    process.env.NODE_ENV = 'development';
+  if (options.production == null && process.env.NODE_ENV !== 'production') {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   } else {
     process.env.NODE_ENV = 'production';
     params.isProduction = true;


### PR DESCRIPTION
The changes in #1608 introduced a bug where brunch will overwrite any user-set value for the `NODE_ENV` environment variable.

For example, the following shell script...

```
export NODE_ENV=staging
node_modules/.bin/brunch build
```

...will build the project with `development` settings, even when I have explicitly set the `NODE_ENV`.

This effectively breaks using more than two environments. I use brunch in conjunction with [the `config` NPM module](https://www.npmjs.com/package/config), and with the current brunch code I cannot build with `staging` settings.

The fix is two-fold:
* Avoid setting a value for `NODE_ENV` if `NODE_ENV` already has a value
* Force the `--production` option if `NODE_ENV` is already set to `production` (e.g. `export NODE_ENV=production; brunch build`)
