### PR TITLE
Fix vendor pattern.

### DIFF
--- a/lib/utils/config-validate.js
+++ b/lib/utils/config-validate.js
@@ -74,7 +74,7 @@ const configBaseSchema = v.object({
   conventions: v.object({
     ignored: v.anymatch.default([/\/_/, /vendor\/(node|j?ruby-.*|bundle)\//]),
     assets: v.anymatch.default(/assets\//),
-    vendor: v.anymatch.default(/^(bower_components|node_modules|vendor)\//),
+    vendor: v.anymatch.default(/(bower_components|node_modules|^vendor)\//),
   }).default({}),
 
   modules: v.object({


### PR DESCRIPTION
Fix for #1628 and #1593. Solution related to https://github.com/brunch/brunch/issues/1593#issuecomment-269223215

Caused by https://github.com/brunch/brunch/pull/1571/commits/247e91ae50fa8d90680caa6a3c45632d3eeaab2c.

@shvaikalesh did [a small unobvious mistake](https://github.com/brunch/brunch/pull/1571/commits/247e91ae50fa8d90680caa6a3c45632d3eeaab2c#diff-9414a6c7096b68cca1b48e1215cf64a8R77) in regular expression. When Brunch is installed globally,  we get a relative path to global Brunch's `process/browser.js`, such as:

```
../path/to/global/brunch/node_modules/process/browser.js
```

… which is usually do not match to `/^(bower_components|node_modules|vendor)\//`, because it doesn't start with `node_modules`.

You can find more precise explanation here: https://github.com/brunch/brunch/issues/1593#issuecomment-269223215.
Solutions explained here: https://github.com/brunch/brunch/issues/1593#issuecomment-269224727

> If path contains `bower_components` or `node_modules`, or starts with `vendor`, then this path corresponds to a vendor file.
> — https://github.com/brunch/brunch/issues/1593#issuecomment-269224727

That's not the best possible solution, but that's OK for now.