### PR TITLE
Fix "sourcesContent" after optimizers are run

### DIFF
--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -161,7 +161,7 @@ const prepareSourceMap = (optimizedMap, sourceFiles) => {
   sourceFiles.forEach(arg => {
     const path = arg.path;
     const source = arg.source;
-    map._sourcesContents[`$${path}`] = source;
+    map._sourcesContents[path] = source;
   });
   return map;
 };


### PR DESCRIPTION
brunch sets the private `._sourcesContents` property of source maps that
come from optimizers:

    map._sourcesContents[`$${path}`] = source

The reason every `path` is prefixed with a `$`, is because the
`mozilla/source-map` module used to do so, but that changed in
mozilla/source-map#228. Now, only the string `__proto__` is prefixed
with a `$`, but not if the runtime supports "null __proto__". If
`!('__proto__' in Object.create(null))` is `true`, the
`mozilla/source-map` module will never prefix any paths with a `$`.

Does Node.js support "null __proto__"?

    $ node -p "!('__proto__' in Object.create(null))"
    true

So, yes it does. I've tested with Node.js 4, 6 and 7.

This commit simply gets rid of the `$` prefixing.

Before:

    $ brunch build --production
    19 Jan 20:28:08 - info: compiled main.js into app.js in 517 ms

    # Note how every source has `null` as content.
    $ grep -o 'sourcesContent.*' public/app.js.map
    sourcesContent":[null]}

After:

    $ brunch build --production
    19 Jan 20:28:59 - info: compiled main.js into app.js in 509 ms

    # Now the actual contents of the source files are present.
    $ grep -o 'sourcesContent.*' public/app.js.map
    sourcesContent":["if (true) {\n  console.log('hello')\n}\n"]}

(The above assumes `overrides: {production: {sourceMaps: true}}` in
brunch-config.js.)