### PR TITLE
Changes to plugin adapter

### DIFF
--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -78,7 +78,10 @@ const getDependencies = (file, compiler) => {
 };
 
 const processAsset = parallel('PROCESS_ASSET', file => {
-  const compilers = respondTo('compileStatic');
+  const compilers = respondTo('compileStatic').filter(compiler => {
+    return compiler.type === 'template';
+  });
+
   const nextCompiler = file => {
     const compiler = pull(compilers, compiler => {
       return compiler.staticPattern.test(file.path);

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -40,8 +40,10 @@ const prettify = object => {
 
 const formatError = file => {
   const error = file.error;
+  const code = error.pipelineCode || 'Processing';
   const message = error.message.trim().replace(/^/gm, '   ');
-  return `${error.pipelineCode || 'Processing'} of ${file.path} failed.\n\n${message}\n`;
+  error.message = `${code} of ${file.path} failed.\n${message}`;
+  return error;
 };
 
 /* compiled 4 files and 145 cached files into app.js

--- a/lib/utils/plugin-adapter.js
+++ b/lib/utils/plugin-adapter.js
@@ -106,8 +106,8 @@ module.exports = plugin => {
     extToRegExp(plugin.extension) ||
     /.^/; // never matches
 
-    plugin.staticTargetExtension = normExt(plugin.staticTargetExtension);
   if (plugin.type === 'template' && plugin.compileStatic) {
+    plugin.staticTargetExtension = normExt(plugin.staticTargetExtension) || '.html';
     plugin.staticPattern = plugin.staticPattern ||
       extToRegExp(plugin.staticExtension) ||
       plugin.pattern;

--- a/lib/utils/plugin-adapter.js
+++ b/lib/utils/plugin-adapter.js
@@ -26,7 +26,7 @@ const normInclude = plugin => {
 
   // Don't call setter (it is probably missing)
   Object.defineProperty(plugin, 'include', {
-    value: [].concat(include),
+    value: include,
     writable: true,
     configurable: true,
   });

--- a/lib/utils/plugin-adapter.js
+++ b/lib/utils/plugin-adapter.js
@@ -106,8 +106,8 @@ module.exports = plugin => {
     extToRegExp(plugin.extension) ||
     /.^/; // never matches
 
-  if (plugin.compileStatic) {
     plugin.staticTargetExtension = normExt(plugin.staticTargetExtension);
+  if (plugin.type === 'template' && plugin.compileStatic) {
     plugin.staticPattern = plugin.staticPattern ||
       extToRegExp(plugin.staticExtension) ||
       plugin.pattern;

--- a/lib/utils/plugin-adapter.js
+++ b/lib/utils/plugin-adapter.js
@@ -1,13 +1,6 @@
 'use strict';
-const debug = require('debug')('brunch:plugin-adapter');
+const microPromisify = require('micro-promisify');
 const logger = require('loggy');
-const promisify = require('micro-promisify');
-const methods = [
-  'getDependencies',
-  'lint',
-  'compile',
-  'optimize',
-];
 
 const normExt = ext => {
   return typeof ext === 'string' ?
@@ -21,63 +14,82 @@ const extToRegExp = ext => {
   return new RegExp(`${escaped}$`, 'i');
 };
 
-const safeWrapInFile = (plugin, key) => {
-  const fn = plugin[key];
-  if (typeof fn !== 'function') return;
+// Normalize includes to an array.
+const normInclude = plugin => {
+  let include = plugin.include;
 
+  if (include == null) {
+    include = [];
+  } else if (typeof include === 'function') {
+    include = include.call(plugin);
+  }
+
+  // Don't call setter (it is probably missing)
+  Object.defineProperty(plugin, 'include', {
+    value: [].concat(include),
+    writable: true,
+    configurable: true,
+  });
+};
+
+const normMethods = plugin => {
+  const methods = {};
+  methods.lint = methods.getDependencies = [bind, promisify(false), thenify, warnIfLong];
+  methods.compile = methods.optimize = [bind, promisify(true), thenify, wrapStrings, warnIfLong];
+  methods.compileStatic = [bind, thenify, wrapStrings, warnIfLong];
+
+  Object.keys(methods).forEach(key => {
+    const fn = plugin[key];
+    if (typeof fn !== 'function') return;
+
+    const decorators = methods[key];
+    const compose = (fn, decorator) => decorator(fn, plugin, key);
+
+    plugin[key] = decorators.reduce(compose, fn);
+  });
+};
+
+const bind = (fn, plugin) => fn.bind(plugin);
+const promisify = returnsFile => fn => {
+  switch (fn.length) {
+    case 1:
+      // Modern API:
+      return fn;
+    case 2:
+      // Legacy API:
+      return returnsFile ?
+        microPromisify(fn) : // fn(file, callback) => void
+        file => fn(file.data, file.path); // fn(data, path) => Promise
+    case 3:
+      // Legacy API: fn(data, path, callback) => void
+      const promisified = microPromisify(fn);
+      return file => promisified(file.data, file.path);
+  }
+};
+
+const thenify = fn => {
+  return file => Promise.resolve(file).then(fn);
+};
+
+const wrapStrings = fn => {
+  return file => fn(file).then(data => {
+    return typeof data === 'string' ? {data} : data;
+  });
+};
+
+const warnIfLong = (fn, plugin, key) => {
   const warningLogInterval = 15000;
   const tooLongMessage = `${plugin.brunchPluginName} is taking too long to ${key}`;
 
-  plugin[key] = file => {
+  return file => {
     const id = setInterval(() => {
       logger.warn(`${tooLongMessage} @ ${file.path}`);
     }, warningLogInterval);
 
-    return fn.call(plugin, file).then(data => {
+    return fn(file).finally(() => {
       clearInterval(id);
-      return typeof data === 'string' ? {data} : data;
-    }, reason => {
-      clearInterval(id);
-      throw reason;
     });
   };
-};
-
-const promisifyMethod = (plugin, key) => {
-  const fn = plugin[key];
-  if (typeof fn !== 'function') return;
-
-  const arity = fn.length;
-
-  // Modern API, skip.
-  // fn(file) => Promise
-  if (arity === 1) return;
-
-  let promisified;
-
-  // Legacy API.
-  if (arity === 2) {
-    if (key === 'lint' || key === 'getDependencies') {
-      // fn(data, path) => Promise
-      promisified = file => fn.call(plugin, file.data, file.path);
-    } else {
-      const bound = promisify(fn);
-      // fn(file, callback) => null
-      promisified = file => bound.call(plugin, file);
-    }
-  }
-
-  // Legacy API.
-  // fn(data, path, callback) => null
-  if (arity === 3) {
-    const bound = promisify(fn);
-    promisified = file => bound.call(plugin, file.data, file.path);
-  }
-
-  if (arity >= 4) throw new Error(`Invalid arity ${arity} for ${plugin.brunchPluginName}.${key}.`);
-
-  debug(`${plugin.brunchPluginName} ${key}() using legacy API (${arity} args)`);
-  plugin[key] = promisified;
 };
 
 module.exports = plugin => {
@@ -86,20 +98,8 @@ module.exports = plugin => {
     plugin.optimize = plugin.minify;
   }
 
-  // Normalize includes to an array.
-  if (typeof plugin.include === 'function') {
-    plugin.include = plugin.include();
-  } else if (plugin.include == null) {
-    plugin.include = [];
-  }
-
-  methods.forEach(key => {
-    promisifyMethod(plugin, key);
-  });
-
-  methods.concat('compileStatic').forEach(key => {
-    safeWrapInFile(plugin, key);
-  });
+  normInclude(plugin);
+  normMethods(plugin);
 
   plugin.targetExtension = normExt(plugin.targetExtension);
   plugin.pattern = plugin.pattern ||


### PR DESCRIPTION
Refactorings aside, this PR:

1) requires plugins with `compileStatic` have `type` equal to `template`
2) makes plugin API a bit more forgiving (e.g. no need to wrap result in `Promise.resolve`)
3) fixes `formatError` swallowing stack traces
4) fixes "takes too long to compile" appearing after compilation failed