### PR TITLE
Send inside the plugin the original path when target is not same as the source

### DIFF
--- a/lib/fs_utils/pipeline.js
+++ b/lib/fs_utils/pipeline.js
@@ -112,9 +112,12 @@ const compile = (file, compiler) => {
     return deps.then(dependencies => {
       const path = compiled.path || file.path;
 
+      let originalPath = file.originalPath || (compiler.targetExtension ? path : undefined);
+
       return Object.assign({}, compiled, {
         dependencies,
         type: compiler.type,
+        originalPath: originalPath,
         path: compiler.targetExtension ?
           path.replace(extRe, compiler.targetExtension) :
           path,

--- a/lib/utils/plugin-adapter.js
+++ b/lib/utils/plugin-adapter.js
@@ -85,7 +85,9 @@ const warnIfLong = (fn, plugin, key) => {
     const id = setInterval(() => {
       logger.warn(`${tooLongMessage} @ ${file.path}`);
     }, warningLogInterval);
-
+    if(file.originalPath) {
+      file.path = file.originalPath;
+    }
     return fn(file).finally(() => {
       clearInterval(id);
     });


### PR DESCRIPTION
#1648 

I hope it didn't affect other plugins. 
Tested with `less-brunch` (with targetExtension) and `postcss-brunch`.
Remove `css-brunch` as useless.
