### PR TITLE
Bump coffee-script to version 1.12.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "anysort": "~1.0",
     "check-dependencies": "~1.0.1",
     "chokidar": "^1.6",
-    "coffee-script": "~1.11",
+    "coffee-script": "~1.12.7",
     "commander": "~2.9",
     "commonjs-require-definition": "~0.6.2",
     "debug": "~2.2",


### PR DESCRIPTION
Hi,

I have tested coffee-script latest version and it seems to work perfectly. Is it possible to update bump it to the latest version through this PR ? And also publish the changes to NPM ?
Thanks