### PR TITLE
Fix source maps

### DIFF
--- a/lib/fs_utils/generate.js
+++ b/lib/fs_utils/generate.js
@@ -86,7 +86,7 @@ const concat = (files, path, definitionFn, autoRequire, config) => {
 
   const processor = file => {
     root.add(file.node);
-    const data = file.node.isIdentity ? file.source : file.data;
+    const data = file.node.isIdentity ? file.data : file.source;
     if (isJs && !/;\s*$/.test(data)) root.add(';');
     return root.setSourceContent(file.node.source, data);
   };

--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -123,7 +123,7 @@ class SourceFile {
 
     const data = file.data;
 
-    return this._updateMap(data, file.sourceMap).then(node => {
+    return this._updateMap(data, file.map).then(node => {
       this.targets = {
         [this.type]: {data, node},
       };


### PR DESCRIPTION
Fixes #1635: Generating source maps with the correct source code and line numbers.

Tested and working in both production and dev mode with buble, uglify.js, postcss and clean-css.
More tests would be appreciated (if you're usiging yarn, you can add the fix from my branch with `yarn add https://github.com/friday/brunch\#fix/wrong-sm-property`, but this branch won't live long so don't keep it after testing).

The problem:
`_updateCache()` in "source_file.js" passed `file.sourceMap` to `_updateMap()`. However `file.sourceMap` doesn't seem to exist. I think it did in 2.9, but was renamed to file.map (or at least file.map exists and using it instead of `file.sourceMap` fixed the problem completely for me).

This also reverts #1756 since it's only fixing the "symptom" (`isIdentity` always being true). Since `isIdentity` works with this PR #1756 has the adverse effect.