### PR TITLE
Allow non-CSS compilers to optionally emit CSS modules

### DIFF
--- a/lib/fs_utils/source_file.js
+++ b/lib/fs_utils/source_file.js
@@ -128,6 +128,14 @@ class SourceFile {
         [this.type]: {data, node},
       };
 
+      const cssExports = file.cssExports;
+      if (cssExports && this.type !== 'stylesheet') {
+        this.targets.stylesheet = {
+          data: cssExports,
+          node: identityNode(cssExports, this.path),
+        };
+      }
+
       const exports = file.exports;
       if (!exports || this.type === 'javascript') return;
 


### PR DESCRIPTION
Allows non-CSS compilers (`template` and `javascript`) to emit CSS code that will be processed by Brunch.

This is useful for single-file Vue.js plugins, as they emit both JS and CSS. Currently, `vue-brunch` relies on injecting CSS using Javascript or dumping the unprocessed CSS to a separate file.

This change is similar to #1240.

How to use it:

```
class MyCompiler {
  compile(params) {
    const compiled = magic(params);
    const cssExports = ".red { color: #f00 }";

    return Promise.resolve({ data: compiled, cssExports });
  }
}
```