### PR TITLE
License Updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+License
+Brunch is released under the MIT License.
+
+Copyright (c) 2011-2018 Paul Miller, Elan Shanker, Nik Graf, Thomas Schranz, Allan Berger, Jan Monschke, Martin Schürrer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [CONTRIBUTING.md](https://github.com/brunch/brunch/blob/master/CONTRIBUT
 
 Brunch is released under the MIT License.
 
-Copyright (c) 2011-2016 Paul Miller, Elan Shanker, Nik Graf,
+Copyright (c) 2011-2018 Paul Miller, Elan Shanker, Nik Graf,
 Thomas Schranz, Allan Berger, Jan Monschke, Martin Schürrer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi there, I am a new user to Brunch and was just doing a comparison of the Github project to a few other similar tools, noticed on the [Brunch Github Community](https://github.com/brunch/brunch/community) page that the project was "missing" a license, even though it's in the readme.

This PR should fix that

- created a `LICENSE` file for Github Community Profile
- Updated end year for license to 2018 in `README.md` and `LICENSE`

Perhaps it makes sense to just reference the `LICENSE` in the `README.md`, but I didn't want to do anything destructive with this PR.

<img width="1018" alt="screen shot 2018-02-19 at 11 53 17 am" src="https://user-images.githubusercontent.com/81055/36393156-a8a4f02a-156b-11e8-95e8-2046f6a75f4c.png">