### PR TITLE
Updating to coffeescript 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "anysort": "~1.0",
     "check-dependencies": "~1.0.1",
     "chokidar": "^2",
-    "coffeescript": "~1.12.7",
+    "coffeescript": "~2.4.1",
     "commander": "~2.9",
     "commonjs-require-definition": "~0.6.2",
     "deppack": "~0.8",


### PR DESCRIPTION
Currently, any custom brunch-server.coffee will run in Coffeescript 1 because of Brunch's dependency on it. For those of us using Coffeescript 2 for our backend, this presents a problem. Coffeescript 2 compiles to ES6, supports async/await, and can handle JSX-style code natively.  Therefore, I would like to request that Brunch support Coffeescript 2 as it has been supporting  Coffeescript 1.

In the event that the community would not like to yet move master to Coffeescript 2, perhaps we could have a tag that differs from the most recent release only in the version of Coffeescript it references in package.json -- then those of us that rely on CS2 can simply point to that tag. 

I've tested CS2 locally--all tests pass, and no functional changes are apparent. The only concern I have is that some community plugins may not be using forwards-compatible CS2 syntax.  I will certainly issue PRs on any plugins we use that have this problem, and plugin maintainers are welcome to contact me if they have trouble upgrading their own plugins.