### PR TITLE
Don’t override NODE_ENV in production mode (fixes #1692)

### DIFF
--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -439,7 +439,7 @@ function initParams(persistent, options) {
   if (options.production == null && process.env.NODE_ENV !== 'production') {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   } else {
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = process.env.NODE_ENV || 'production';
     params.isProduction = true;
     params.env.unshift('production');
   }


### PR DESCRIPTION
fixes #1692