### PR TITLE
⚠️ Stripping trailing slash before matching conventions.

### DIFF
--- a/lib/fs_utils/asset.js
+++ b/lib/fs_utils/asset.js
@@ -11,10 +11,11 @@ const EMPTY_ARR = Object.freeze([]);
 
 // Returns all parent directories:
 // < parentDirs('app/assets/thing/index.html')
-// > ['app/', 'app/assets/', 'app/assets/thing/']
+// > ['app', 'app/assets', 'app/assets/thing']
 const parentDirs = path => {
   return path.split('/').map((part, index, parts) => {
-    return parts.slice(0, index).concat(part, '').join('/');
+    const path = parts.slice(0, index).concat(part, '').join('/');
+    return path.substr(-1) !== '/'  ? path : path.substr(0, path.length - 1);
   });
 };
 


### PR DESCRIPTION
https://github.com/brunch/brunch/issues/1890

It seems that anymatch 3.1.3 no longer automatically strips trailing slashes from paths before matching. This PR handles the stripping of the trailing slash before the match operation occurs.

Brunch won't work with new versions of anymatch without these changes, and the current package.json will not prevent new projects from pulling anymatch 3.1.3+. Thus nothing will work for new users until this is fixed.

**Also, without this patch, npm update will break existing projects.** This break may be silent as the index.html and other assets may already be built. They will NOT be correctly rebuilt without this patch. Furthermore, any CI/CD that depends on spinning this up from scratch will fail.

This patch seems to play nice with anymatch 3.1.1 and 3.1.2.